### PR TITLE
Update the cloud icon to tab into it and use the hand pointer.

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -142,13 +142,13 @@ Nicholas and Damien.
                     </a>
                 </div>
                 <div id="script-icons" class="vbox">
-                    <div class="holder">
+                    <div class="holder saved-state" tabindex="7">
                         <div id="cloud-status" class="status-icon">
                             <i class="fa fa-cloud-upload"
                                 title="Script loaded"></i>
                         </div>
                     </div>
-                    <a id="link-log" class="holder" tabindex="7" href="#"
+                    <a id="link-log" class="holder" tabindex="8" href="#"
                         title="Read a log of all the things you've been up to">
                         <div class="status-icon">
                             <i class="fa fa-bug"></i>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -96,7 +96,8 @@ body, input {
   cursor: pointer;
 }
 
-.zoomer {
+.zoomer, 
+.saved-state {
   cursor: pointer !important;
 }
 


### PR DESCRIPTION
The current cloud/save icon is not set to the link cursor because it is being ignored as the first child of:

```
 #script-icons > *:not(:first-child) {
   display: inline-block;
   cursor: pointer;
 }
```

Maybe the `:not(:first-child)` could be removed together the the `zoomer` class, but because it seems deliberate to only have the second item as `display: inline-block;` I've updated it to follow the same principle.

Also added the ability to tab into that icon, which for some reason was left out.