### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/help.html
+++ b/help.html
@@ -251,7 +251,7 @@ display.scroll("Hello, World!")</code></pre>
     it can't work out what you're coding about).</p>
 
     <p>If you're unsure what to do
-    <a href="http://microbit-micropython.readthedocs.org/en/latest/">go read the
+    <a href="https://microbit-micropython.readthedocs.io/en/latest/">go read the
     MicroPython docs</a>. Alternatively, just ask someone who knows what they're
     doing. If no such person is available you could just follow this handy flow
     chart:</p>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.