### PR TITLE
Move submodule url from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "blockly"]
 	path = blockly
-	url = git@github.com:google/blockly.git
+	url = https://github.com/google/blockly.git
 [submodule "microbit_blocks"]
 	path = microbit_blocks
-	url = git@github.com:PyBlocks/microbit_blocks.git
+	url = https://github.com/PyBlocks/microbit_blocks.git


### PR DESCRIPTION
Fixes #11.

I've tried this locally and get around the issue mentioned above. I am not quite sure what the implications of changing this URL has on existing local repository clones. I would assume it shouldn't be an issue as it is only used when the submodule is touched, and they are basically pointing to the same thing, but I'll google around to find more info about this.

(Edit: Had a look around and seems like a fairly side-effect-free change, couldn't find any evidence of problems by changing this url in this manner.)