### PR TITLE
Add additional flag to easily identify experimental versions

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -339,7 +339,8 @@ web_editor({
     'flags': {
       'blocks': true,
       'snippets': true,
-      'share': true
+      'share': true,
+      'experimental': false
     },
 });
         </script>

--- a/python-main.js
+++ b/python-main.js
@@ -337,6 +337,10 @@ function web_editor(config) {
             EDITOR.setCode(config.translate.code.start);
         }
         EDITOR.ACE.gotoLine(EDITOR.ACE.session.getLength());
+        // If configured as experimental update editor background to indicate it
+        if(config.flags.experimental) {
+            EDITOR.ACE.renderer.scroller.style.backgroundImage = "url('static/img/experimental.png')"
+        }
         // Configure the zoom related buttons.
         $("#zoom-in").click(function (e) {
             e.stopPropagation();


### PR DESCRIPTION
New flag that will make it very visible if a version of the editor is experimental:
![image](https://user-images.githubusercontent.com/29712657/30658249-04921e28-9e32-11e7-801d-c7afb225f437.png)
