### PR TITLE
Minor refactor to decouple hex generation from button actions.

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -69,11 +69,11 @@ Nicholas and Damien.
     </head>
     <body>
         <script type="application/javascript">
-        <!-- VERSION INFORMATION -->
-        EDITOR_VERSION = "1.1.2";
-        UPY_VERSION = "1.0.1";
+            // VERSION INFORMATION
+            EDITOR_VERSION = "1.1.2";
+            UPY_VERSION = "1.0.1";
         </script>
-        
+
         <script id="load-template" type="x-tmpl-mustache">
             <h2><i class="fa fa-upload"></i> <strong>{{ title }}</strong></h2>
             <div class="load-drag-target" id="load-drag-target">
@@ -107,7 +107,6 @@ Nicholas and Damien.
                 </tr>
                 {{/snippets}}
             </table>
-
         </script>
         <script id="share-template" type="x-tmpl-mustache">
             <h2><i class="fa fa-share-alt"></i> <strong>{{ title }}</strong></h2>
@@ -321,7 +320,7 @@ web_editor({
       'alerts': {
         'download': 'Safari has a bug that means your work will be downloaded as an un-named file. Please rename it to something ending in .hex. Alternatively, use a browser such as Firefox or Chrome. They do not suffer from this bug.',
         'save': 'Safari has a bug that means your work will be downloaded as an un-named file. Please rename it to something ending in .py. Alternatively, use a browser such as Firefox or Chrome. They do not suffer from this bug.',
-        'length': 'Oops! Your script is to long given the limited memory on the device.',
+        'length': 'Oops! Your script is too long given the limited memory on the device.',
         'snippets': 'Snippets are disabled when blockly is enabled.'
       },
       'confirms': {

--- a/python-main.js
+++ b/python-main.js
@@ -10,8 +10,10 @@ Returns an object that defines the behaviour of the Python editor. The editor
 is attached to the div with the referenced id.
 */
 function pythonEditor(id) {
+    'use strict';
+
     // An object that encapsulates the behaviour of the editor.
-    editor = {};
+    var editor = {};
     editor.initialFontSize = 22;
     editor.fontSizeStep = 4;
 
@@ -56,8 +58,8 @@ function pythonEditor(id) {
     // Triggers a snippet by name in the editor.
     editor.triggerSnippet = function(snippet) {
         var snippetManager = ace.require("ace/snippets").snippetManager;
-        var snippet = snippetManager.snippetNameMap.python[snippet];
-        if(snippet) {
+        snippet = snippetManager.snippetNameMap.python[snippet];
+        if (snippet) {
             snippetManager.insertSnippet(ACE, snippet.content);
         }
     };
@@ -116,6 +118,10 @@ the editor to the DOM (web-page).
 See the comments in-line for more information.
 */
 function web_editor(config) {
+    'use strict';
+
+    // Instance of the pythonEditor object (the ACE text editor wrapper)
+    var EDITOR = pythonEditor('editor');
 
     // Indicates if there are unsaved changes to the content of the editor.
     var dirty = false;
@@ -208,7 +214,7 @@ function web_editor(config) {
             return encodeURIComponent(f) + "=true";
         }).join("&");
         helpAnchor.attr("href", helpAnchor.attr("href") + "?" + featureQueryString); 
-    };
+    }
 
     // Update the docs link to append MicroPython version
     var docsAnchor = $("#docs-link"); 
@@ -221,7 +227,6 @@ function web_editor(config) {
         // Set version in document title
         document.title = document.title + ' ' + EDITOR_VERSION;
         // Setup the Ace editor.
-        EDITOR = pythonEditor('editor');
         if(message.n && message.c && message.s) {
             var template = $('#decrypt-template').html();
             Mustache.parse(template);
@@ -309,13 +314,25 @@ function web_editor(config) {
         $("#command-download").focus();
     }
 
+    // Generates the text for a hex file with MicroPython and the user code
+    function generateFullHexStr() {
+        var firmware = $("#firmware").text();
+        var fullHexStr = '';
+        try {
+            fullHexStr = EDITOR.getHexFile(firmware);
+        } catch(e) {
+            // We generate a user readable error here to be caught and displayed
+            throw new Error(config.translate.alerts.length);
+        }
+        return fullHexStr;
+    }
+
     // This function describes what to do when the download button is clicked.
     function doDownload() {
-        var firmware = $("#firmware").text();
         try {
-            var output = EDITOR.getHexFile(firmware);
+            var output = generateFullHexStr();
         } catch(e) {
-            alert(config.translate.alerts.length);
+            alert('Error:\n' + e.message);
             return;
         }
         var ua = navigator.userAgent.toLowerCase();

--- a/tests/spec/python-spec.js
+++ b/tests/spec/python-spec.js
@@ -43,7 +43,7 @@ describe("An editor for MicroPython on the BBC micro:bit:", function() {
         it("A tab is the same as 4 spaces.", function() {
             var editor = pythonEditor('editor');
             expect(editor.ACE.getOption('tabSize')).toBe(4);
-        })
+        });
 
         it("A tab is 'soft'.", function() {
             var editor = pythonEditor('editor');


### PR DESCRIPTION
This way new features that need to hook to this functionality only need to fo a function call with less chance for integration conflicts.

The overlap area turned out to be smaller than I expected, so the main change is the creation of `generateFullHexStr()`.

Also added `'use strict';` to the two objects and edited minor things jslint complained about.