### PR TITLE
Script name change on file load (fs)

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -337,6 +337,7 @@ function web_editor(config) {
     // Loads Python code into the editor and/or filesystem
     function loadPy(filename, codeStr) {
         var isModule = isPyModule(codeStr);
+        var filesystemName = filename;
         filename = isModule ? filename : 'main.py';
         var moduleName = filename.replace('.py', '');
         var showModuleLoadedAlert = true;
@@ -361,7 +362,7 @@ function web_editor(config) {
                 alert(config.translate.alerts.module_added.replace('{{module_name}}', moduleName));
             }
         } else {
-            setName(filename.replace('.py', ''));
+            setName(filesystemName.replace('.py', ''));
             setDescription(config.translate.drop.python);
             EDITOR.setCode(codeStr);
             EDITOR.ACE.gotoLine(EDITOR.ACE.session.getLength());

--- a/python-main.js
+++ b/python-main.js
@@ -361,7 +361,7 @@ function web_editor(config) {
                 alert(config.translate.alerts.module_added.replace('{{module_name}}', moduleName));
             }
         } else {
-            setName(moduleName.replace('.py', ''));
+            setName(moduleName);
             setDescription(config.translate.drop.python);
             EDITOR.setCode(codeStr);
             EDITOR.ACE.gotoLine(EDITOR.ACE.session.getLength());

--- a/python-main.js
+++ b/python-main.js
@@ -337,9 +337,8 @@ function web_editor(config) {
     // Loads Python code into the editor and/or filesystem
     function loadPy(filename, codeStr) {
         var isModule = isPyModule(codeStr);
-        var filesystemName = filename;
-        filename = isModule ? filename : 'main.py';
         var moduleName = filename.replace('.py', '');
+        filename = isModule ? filename : 'main.py';
         var showModuleLoadedAlert = true;
         if (isModule && micropythonFs.exists(filename)) {
             if (!confirm(config.translate.confirms.replace_module.replace('{{module_name}}', moduleName))) {
@@ -362,7 +361,7 @@ function web_editor(config) {
                 alert(config.translate.alerts.module_added.replace('{{module_name}}', moduleName));
             }
         } else {
-            setName(filesystemName.replace('.py', ''));
+            setName(moduleName.replace('.py', ''));
             setDescription(config.translate.drop.python);
             EDITOR.setCode(codeStr);
             EDITOR.ACE.gotoLine(EDITOR.ACE.session.getLength());


### PR DESCRIPTION
Prevent script name from changing when invalid files are loaded, or when files are added to the filesystem but don't replace editor content.

Closes #108

PR is against `filesystem` branch, see https://github.com/bbcmicrobit/PythonEditor/pull/119#discussion_r263718891