### PR TITLE
python-main: Make the EDITOR instance available globally.

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -120,8 +120,8 @@ See the comments in-line for more information.
 function web_editor(config) {
     'use strict';
 
-    // Instance of the pythonEditor object (the ACE text editor wrapper)
-    var EDITOR = pythonEditor('editor');
+    // Global (useful for testing) instance of the ACE wrapper object
+    window.EDITOR = pythonEditor('editor');
 
     // Indicates if there are unsaved changes to the content of the editor.
     var dirty = false;


### PR DESCRIPTION
This variable stoped being global when `use strict` was added to the file.

This is very useful for end-to-end testing, to be able to retrieve the code from the ACE editor, as it is broken down in multiple div elements by ACE.