### PR TITLE
Fix for #139 - Changed editor var to load blockly

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -438,7 +438,7 @@ function web_editor(config) {
             dirty = false;
             blockly.hide();
             $('#editor').attr('title', '');
-            editor.ACE.setReadOnly(false);
+            EDITOR.ACE.setReadOnly(false);
             $("#command-snippet").removeClass('disabled');
             $("#command-snippet").off('click');
             $("#command-snippet").click(function () {
@@ -450,7 +450,7 @@ function web_editor(config) {
                     return;
                 }
             }
-            editor.ACE.setReadOnly(true);
+            EDITOR.ACE.setReadOnly(true);
             $('#editor').attr('title', 'The code editor is read-only when blocks are active.');
             $("#command-snippet").off('click');
             $("#command-snippet").click(function () {


### PR DESCRIPTION
Fix for blockly window not opening by changing the specified editor var to the correct one ('EDITOR' instead of 'editor').

fixes #139 