### PR TITLE
Add action class to floating help links

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -199,10 +199,10 @@ Nicholas and Damien.
                 </a>
                 <div class="helpsupport_container">
                     <div class="helpsupport_lhs">
-                        <div class="helpsupport"><a id="docs-link" title="View the documentation for MicroPython" href="https://microbit-micropython.readthedocs.io/" target="_blank">Documentation</a></div>
-                        <div class="helpsupport"><a id="help-link" title="Open help for this editor in a new tab" href="help.html" target="_blank" >Help</a></div>
-                        <div class="helpsupport"><a title="Get support for your micro:bit in a new tab" href="https://support.microbit.org/support/home" target="_blank">Support</a></div>
-                        <div class="helpsupport hidden" id="known-issues"><a title="View open issues for the Python Editor in GitHub" href="https://github.com/bbcmicrobit/PythonEditor/issues" target="_blank">Issue Tracker</a></div>
+                        <div class="helpsupport"><a id="docs-link" class="action" title="View the documentation for MicroPython" href="https://microbit-micropython.readthedocs.io/" target="_blank">Documentation</a></div>
+                        <div class="helpsupport"><a id="help-link" class="action" title="Open help for this editor in a new tab" href="help.html" target="_blank" >Help</a></div>
+                        <div class="helpsupport"><a id="support-link" class="action" title="Get support for your micro:bit in a new tab" href="https://support.microbit.org/support/home" target="_blank">Support</a></div>
+                        <div class="helpsupport hidden" id="known-issues"><a id="issues-link" class="action" title="View open issues for the Python Editor in GitHub" href="https://github.com/bbcmicrobit/PythonEditor/issues" target="_blank">Issue Tracker</a></div>
                     </div>
                     <div class="helpsupport_rhs">
                         <div class="helpsupport">Editor Version: <script>document.write(EDITOR_VERSION);</script></div>


### PR DESCRIPTION
This commit adds the action class to the floating help links so that they can be measured.