### PR TITLE
Flash button now replaces download

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -158,18 +158,8 @@ Nicholas and Damien.
                     </div>
                     <div class="roundlabel">Connect</div>
                 </a>
-                <a href="#" class="roundbutton hidden" id="command-flash"
-                    tabindex="3"
-                    title="Flash your project directly to your micro:bit">
-                    <div class="roundsymbol">
-                        <svg class="svg svg-icon-touchdevelop" viewBox="50 50 380 380" xmlns="http://www.w3.org/2000/svg" role="presentation" aria-label="flash">
-                            <path d="m 295.37672,362.40336 -41.029,-41.029 0,72.8347 -27.352,0 -0.001,-72.8347 -41.029,41.029 0,-31.911 34.68462,-34.68462 20.02138,-20.02138 54.705,54.706 z m -98.203,-181.9 c 0,9.128 -7.406,16.539 -16.541,16.539 -9.146,0 -16.535,-7.411 -16.535,-16.539 0,-9.131 7.389,-16.548 16.535,-16.548 9.135,0 16.541,7.417 16.541,16.548 z m 121.494,-0.003 c 0,9.129 -7.413,16.542 -16.548,16.542 -9.129,0 -16.537,-7.413 -16.537,-16.542 0,-9.131 7.408,-16.547 16.537,-16.547 9.135,0 16.548,7.416 16.548,16.547 z m -16.544,81.93 -122.554,-0.202 c -45.667,0 -82.284997,-36.553 -82.284997,-81.732 0,-45.179 36.756997,-81.934 81.936997,-81.934 l 122.902,0 c 45.177,0 81.9344,36.755 81.9344,81.934 0,45.179 -36.7574,81.934 -81.9344,81.934 z m 49.164,-81.934 c 0,-27.105 -22.059,-49.164 -49.164,-49.164 l -122.902,0 c -27.107,0 -49.159,22.059 -49.159,49.164 0,27.112 22.052,49.164 49.159,49.164 l 122.902,0 c 27.105,0 49.164,-22.052 49.164,-49.164 z" id="path3341" inkscape:connector-curvature="0" style="fill:currentColor" sodipodi:nodetypes="cccccccccccssssssssssccsssscsssssss" />
-                        </svg>
-                    </div>
-                    <div class="roundlabel">Flash</div>
-                </a>
                 <a href="#" class="roundbutton" id="command-save"
-                    tabindex="4"
+                    tabindex="3"
                     title="Save your Python code to your computer">
                     <div class="roundsymbol">
                         <i class="fa fa-download"></i>
@@ -177,7 +167,7 @@ Nicholas and Damien.
                     <div class="roundlabel">Save</div>
                 </a>
                 <a href="#" class="roundbutton" id="command-load"
-                    tabindex="5"
+                    tabindex="4"
                     title="Load Python code or hex file into the editor">
                     <div class="roundsymbol">
                         <i class="fa fa-upload"></i>
@@ -185,7 +175,7 @@ Nicholas and Damien.
                     <div class="roundlabel">Load</div>
                 </a>
                 <a href="#" class="roundbutton hidden" id="command-serial"
-                    tabindex="6"
+                    tabindex="5"
                     title="Connect to your micro:bit via serial">
                     <div class="roundsymbol">
                         <svg class="svg svg-icon-touchdevelop" viewBox="50 50 380 380" xmlns="http://www.w3.org/2000/svg" role="presentation" aria-label="serial">
@@ -198,7 +188,7 @@ Nicholas and Damien.
                     <div class="roundlabel">Open Serial</div>
                 </a>
                 <a href="#" class="roundbutton hidden" id="command-blockly"
-                    tabindex="7"
+                    tabindex="6"
                     title="Click to create code with blockly">
                     <div class="roundsymbol">
                       <svg class="svg svg-icon-touchdevelop" viewBox="-20 0 500 500" xmlns="http://www.w3.org/2000/svg" role="presentation" aria-label="touchdevelop,white">
@@ -208,7 +198,7 @@ Nicholas and Damien.
                     <div class="roundlabel">Blockly</div>
                 </a>
                 <a href="#" class="roundbutton hidden" id="command-snippet"
-                    tabindex="8"
+                    tabindex="7"
                     title="Click to select a snippet (code shortcut)">
                     <div class="roundsymbol">
                         <i class="fa fa-cogs"></i>
@@ -216,7 +206,7 @@ Nicholas and Damien.
                     <div class="roundlabel">Snippets</div>
                 </a>
                 <a href="#" class="roundbutton"
-                    id="command-help" tabindex="9"
+                    id="command-help" tabindex="8"
                     title="Discover helpful resources">
                     <div class="roundsymbol">
                         <i class="fa fa-question"></i>
@@ -235,7 +225,7 @@ Nicholas and Damien.
                     </div>
                 </div>
                 <a href="#" class="roundbutton hidden"
-                    id="command-share" tabindex="10"
+                    id="command-share" tabindex="9"
                     title="Create a link to share your script">
                     <div class="roundsymbol">
                         <i class="fa fa-share-alt"></i>
@@ -243,14 +233,14 @@ Nicholas and Damien.
                     <div class="roundlabel">Share</div>
                 </a>
                 <div id="script-icons" class="vbox">
-                    <a class="holder zoomer" tabindex="11" id="zoom-in"
+                    <a class="holder zoomer" tabindex="10" id="zoom-in"
                         href="#">
                         <div class="status-icon">
                             <i class="fa fa-search-plus"
                                 title="Zoom in"></i>
                         </div>
                     </a>
-                    <a class="holder zoomer" tabindex="12" id="zoom-out"
+                    <a class="holder zoomer" tabindex="11" id="zoom-out"
                         href="#">
                         <div class="status-icon">
                             <i class="fa fa-search-minus"

--- a/python-main.js
+++ b/python-main.js
@@ -123,6 +123,9 @@ function web_editor(config) {
     // Instance of the pythonEditor object (the ACE text editor wrapper)
     var EDITOR = pythonEditor('editor');
 
+    // Represents the REPL terminal
+    var REPL = null;
+
     // Indicates if there are unsaved changes to the content of the editor.
     var dirty = false;
 
@@ -154,6 +157,12 @@ function web_editor(config) {
     // Set the font size of the text currently displayed in the editor.
     function setFontSize(size) {
         EDITOR.ACE.setFontSize(size);
+        $("#request-repl")[0].style.fontSize = "" + size + "px";
+
+        // Only update font size if REPL is open
+        if ($("#repl").css('display') != 'none') {
+             REPL.prefs_.set('font-size', size);
+        }
     }
 
     // Sets up the zoom-in functionality.
@@ -662,10 +671,13 @@ function web_editor(config) {
             $("#repl").hide();
             $("#request-repl").hide();
             $("#editor-container").show();
-            window.daplink.stopSerialRead();
             $("#command-serial").attr("title", "Connect to your micro:bit via serial");
             $("#command-serial > .roundlabel").text("Open Serial");
         }
+
+        window.daplink.stopSerialRead();
+        $("#repl").empty();
+        REPL = null;
 
         window.daplink.disconnect();
 
@@ -761,9 +773,6 @@ function web_editor(config) {
             $("#command-serial").attr("title", "Close the serial connection and go back to the editor");
             $("#command-serial > .roundlabel").text("Close Serial");
 
-            // Empty #repl to remove any previous terminal interfaces
-            $("#repl").empty();
-
             window.daplink.connect()
             .then( function() {
                 return window.daplink.setSerialBaudrate(115200);
@@ -786,63 +795,65 @@ function web_editor(config) {
                     return;
                 }
 
-
                 $("#flashing-overlay-error").html('<div>' + err + '</div><div>Please restart your micro:bit and try again</div><a href="#" onclick="flashErrorClose()">Close</a>');
             });
         }
     }
 
     function setupHterm(){
-               hterm.defaultStorage = new lib.Storage.Local();
-               var t = new hterm.Terminal("opt_profileName");
-               t.options_.cursorVisible = true;
+       if (REPL == null) {
+         hterm.defaultStorage = new lib.Storage.Local();
 
-               var daplinkReceived = false;
+         REPL = new hterm.Terminal("opt_profileName");
+         REPL.options_.cursorVisible = true;
+         REPL.prefs_.set('font-size', 22);
 
-               t.onTerminalReady = function() {
-                   var io = t.io.push();
+         var daplinkReceived = false;
 
-                   io.onVTKeystroke = function(str) {
-                        window.daplink.serialWrite(str);
-                   };
+         REPL.onTerminalReady = function() {
+             var io = REPL.io.push();
 
-                   io.sendString = function(str) {
-                        window.daplink.serialWrite(str);
-                   };
+             io.onVTKeystroke = function(str) {
+                  window.daplink.serialWrite(str);
+             };
 
-                   io.onTerminalResize = function(columns, rows) {
-                   };
+             io.sendString = function(str) {
+                  window.daplink.serialWrite(str);
+             };
 
+             io.onTerminalResize = function(columns, rows) {
+             };
+         };
 
-               };
+         REPL.decorate(document.querySelector('#repl'));
+         REPL.installKeyboard();
 
-               $("#editor-container").hide();
-               $("#repl").show();
-               $("#request-repl").show();
+         window.daplink.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, function(data) {
+                 REPL.io.print(data); // first byte of data is length
+                 daplinkReceived = true;
+         });
+       }
 
-               t.decorate(document.querySelector('#repl'));
-               t.installKeyboard();
+       $("#editor-container").hide();
+       $("#repl").show();
+       $("#request-repl").show();
 
-               // Recalculate terminal height
-               $("#repl > iframe").css("position", "relative");
-               $("#repl").attr("class", "hbox flex1");
+       // Recalculate terminal height
+       $("#repl > iframe").css("position", "relative");
+       $("#repl").attr("class", "hbox flex1");
+       REPL.prefs_.set('font-size', getFontSize());
 
-               window.daplink.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, function(data) {
-                       t.io.print(data); // first byte of data is length
-                       daplinkReceived = true;
-               });
-
-               /* Don't do this automatically
-               // Send ctrl-C to get the terminal up
-               var attempt = 0;
-               var getPrompt = setInterval(
-                       function(){
-                            daplink.serialWrite("\x03");
-                            console.log("Requesting REPL...");
-                            attempt++;
-                            if(attempt == 5 || daplinkReceived) clearInterval(getPrompt);
-                        }, 200);
-               */
+       /* Don't do this automatically
+       // Send ctrl-C to get the terminal up
+       var attempt = 0;
+       var getPrompt = setInterval(
+               function(){
+                    daplink.serialWrite("\x03");
+                    console.log("Requesting REPL...");
+                    attempt++;
+                    if(attempt == 5 || daplinkReceived) clearInterval(getPrompt);
+                }, 200);
+       */
     }
 
     // handling what to do when they're clicked.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -507,5 +507,10 @@ div.load-form {
 }
 
 #request-repl {
-    display: none; cursor: pointer; background-color: #3758ce; padding: .2em; color: #fff;
+    display: none;
+    cursor: pointer;
+    background-color: #3758ce;
+    padding: .2em;
+    color: #fff;
+    font-size: 22px;
 }


### PR DESCRIPTION
This commit updates the webUSB behavior so that when connected the flash button replaces the download button instead of a new flash button appearing.

![Capture](https://user-images.githubusercontent.com/49149587/58551056-1af29c00-8207-11e9-971a-a7a9a9525cb5.PNG)

This commit also reworks the connect/disconnect and download/flash buttons slightly making their div ID change when they do which will allow for better checking of state and tracking of when these buttons are pressed. (Previously a connect and disconnect would both be tracked as a connect event whereas now they can be tracked independently)

Finally this PR also includes a bug fix for #105