### PR TITLE
Use Storage.Memory() instead of Local Storage for hterm prefs

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -792,7 +792,7 @@ function web_editor(config) {
     }
 
     function setupHterm(){
-               hterm.defaultStorage = new lib.Storage.Local();
+               hterm.defaultStorage = new lib.Storage.Memory();
                var t = new hterm.Terminal("opt_profileName");
                t.options_.cursorVisible = true;
 


### PR DESCRIPTION
We don't need to keep the prefs longer than a single session so store in a JS object rather than local storage