### PR TITLE
Make micropythonFs global to enable metric access

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -122,7 +122,7 @@ function web_editor(config) {
     var dirty = false;
 
     // MicroPython filesystem to be initialised on page load.
-    var micropythonFs;
+    window.micropythonFs = undefined;
 
     // Sets the description associated with the code displayed in the UI.
     function setDescription(x) {


### PR DESCRIPTION
This makes the micropythonFs object public in the same way the EDITOR is, so that we can access it globally which enables us to track metrics such as the number of files in the filesystem.