### PR TITLE
Restore the original colours to starter-template.css.

### DIFF
--- a/static/css/starter-template.css
+++ b/static/css/starter-template.css
@@ -37,27 +37,27 @@ video {
 .roundsymbol {
   width: 10rem;
   height: 10rem;
-  border: 6px solid #febf2e;
+  border: 6px solid #FFCC33;
   border-radius: 50%;
   margin: .2rem;
   margin-bottom: 0;
   text-align: center;
   font-size: 4rem;
   padding-top: .3em;
-  color: #3758ce;
+  color: #336699;
   background: #FFFFFF;
 }
 .roundsymbol-sm {
   width: 5rem;
   height: 5rem;
-  border: 6px solid #febf2e;
+  border: 6px solid #FFCC33;
   border-radius: 50%;
   margin: .2rem;
   margin-bottom: 0;
   text-align: center;
   font-size: 2rem;
   padding-top: .3em;
-  color: #3758ce;
+  color: #336699;
   background: #FFFFFF;
 }
 


### PR DESCRIPTION
On the top the colours in current master and on the bottom the colours set by this PR:

![image](https://user-images.githubusercontent.com/29712657/60957008-cc531a00-a2fb-11e9-9910-df134d39980c.png)

These should then be replaced in the deployment repo with the `style-foundation.css` file.

This was used in the help.html page:
![image](https://user-images.githubusercontent.com/29712657/60957381-716df280-a2fc-11e9-8b49-33f73d3dee69.png)

To:
![image](https://user-images.githubusercontent.com/29712657/60957399-7cc11e00-a2fc-11e9-9bf5-0b0479078d4f.png)
