### PR TITLE
Add action class to Options menu items.

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -244,14 +244,14 @@ Nicholas and Damien.
                         <div class="buttons_menu_item">
                             <span class="menu-switch-label">Autocomplete:</span>
                             <label class="menu-switch">
-                                <input type="checkbox" id="menu-switch-autocomplete">
+                                <input type="checkbox" class="action" id="menu-switch-autocomplete">
                                 <span class="menu-switch-slider"></span>
                             </label>
                         </div>
                         <div class="buttons_menu_item" id="autocomplete-enter">
                             <span class="menu-switch-label">┗ On Enter:</span>
                             <label class="menu-switch">
-                                <input type="checkbox" id="menu-switch-autocomplete-enter" checked>
+                                <input type="checkbox" class="action" id="menu-switch-autocomplete-enter" checked>
                                 <span class="menu-switch-slider"></span>
                             </label>
                         </div>


### PR DESCRIPTION
Adding it to other elements, like the label or div, causes the click handler to fire twice, so it *has* to be added to the input element.