### PR TITLE
startSerialRead: 1ms

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -851,7 +851,7 @@ function web_editor(config) {
                 return window.daplink.getSerialBaudrate();
             })
             .then(function(baud) {
-                window.daplink.startSerialRead(50);
+                window.daplink.startSerialRead(1);
                 lib.init(setupHterm);
             })
             .catch(function(err) {


### PR DESCRIPTION
Serial data is polled at an interval set in `startSerialRead`

Setting this to 1ms appears to allow all the serial data for the `help()` command to be displayed

```
    public startSerialRead(serialDelay: number = DEFAULT_SERIAL_DELAY) {
        this.stopSerialRead();
        this.timer = setInterval(() => {
            return this.send(DAPLinkSerial.READ)
            .then(serialData => {
                if (serialData.byteLength > 0) {
                    // check if there is any data returned from the device
                    // first byte contains the vendor code
                    // second byte contains the actual length of data read from the device
                    const dataLength = serialData.getUint8(1);
                    if (dataLength !== 0) {
                        const offset = 2;
                        const dataArray = serialData.buffer.slice(offset, offset + dataLength);
                        const numberArray = Array.prototype.slice.call(new Uint8Array(dataArray));
                        const data = String.fromCharCode.apply(null, numberArray);
                        this.emit(DAPLink.EVENT_SERIAL_DATA, data);
                    }
                }
            });
        }, serialDelay);
```