### PR TITLE
UI: Update small buttons CSS to use all vertical space.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -143,23 +143,23 @@ h2 {
 }
 
 #small-icons .status-icon {
-  width: 2rem;
-  height: 2rem;
+  width: 37px;
+  height: 37px;
   border: 6px solid #FFCC33;
   border-radius: 50%;
   margin: .2rem;
   text-align: center;
-  font-size: 1.3rem;
-  line-height: 2.1rem;
-  padding: .1em;
+  font-size: 1.4rem;
+  line-height: 2.4rem;
+  padding: 0;
   font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Symbola", sans-serif;
   color: #336699;
   background: #FFFFFF;
 }
 
 #small-icons .holder {
-  width: 54px;
-  min-width: 54px;
+  width: 56px;
+  min-width: 56px;
   color: #336699;
   text-decoration: none;
   text-align: center;


### PR DESCRIPTION
Extends the small buttons to use all available vertical space and increases the font size slightly.

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/29712657/62957065-f82a5980-bdeb-11e9-9c0a-5b7a71cac907.png) | ![image](https://user-images.githubusercontent.com/29712657/62957345-84d51780-bdec-11e9-8f12-608ae706337e.png) | 