### PR TITLE
Add partial flashing to Python Editor.

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -253,6 +253,13 @@ Nicholas and Damien.
                                 </li>
                             </ul>
                         </div>
+                        <div class="buttons_menu_item">
+                            <span id="partial-flashing" class="menu-switch-label">Partial Flashing:</span>
+                            <label class="menu-switch" id="menu-switch-partial-flashing-label">
+                                <input type="checkbox" class="action" id="menu-switch-partial-flashing" checked>
+                                <span class="menu-switch-slider"></span>
+                            </label>
+                        </div>
                     </div>
                 </div>
                 <a href="#" class="roundbutton action" id="command-help"

--- a/lang/en.js
+++ b/lang/en.js
@@ -179,6 +179,7 @@ var language = {
     'options-dropdown': {
       'autocomplete': 'Autocomplete',
       'on-enter': 'On Enter',
+      'partial-flashing': 'Partial Flashing',
       'lang-select': 'Select Language:'
     }
   }

--- a/lang/es.js
+++ b/lang/es.js
@@ -179,6 +179,7 @@ var language = {
     'options-dropdown': {
       'autocomplete': 'Autocompletar',
       'on-enter': 'Al presionar Intro',
+      'partial-flashing': 'Partial Flashing',
       'lang-select': 'Seleccionar Idioma:'
     }
   }

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -179,6 +179,7 @@ var language = {
       'options-dropdown': {
          'autocomplete': 'Autocomplete',
          'on-enter': 'Na Enter:',
+         'partial-flashing': 'Partial Flashing',
          'lang-select': 'Wybierz Język:'
       }
    }

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -1,0 +1,697 @@
+/*
+    This file is made up of a combination of original code, along with code extracted from the following repositories:
+    https://github.com/mmoskal/dapjs/tree/a32f11f54e9e76a9c61896ddd425c1cb1a29c143
+    https://github.com/microsoft/pxt-microbit
+
+    The pxt-microbit license is included below.
+*/
+/*
+    PXT - Programming Experience Toolkit
+
+    The MIT License (MIT)
+
+    Copyright (c) Microsoft Corporation
+
+    All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+*/
+
+'use strict';
+
+let PartialFlashingUtils = {
+    pageSize: 1024,
+    numPages: 256,
+    log: function() {},
+    // log: console.log,
+
+    // The Control/Status Word register is used to configure and control transfers through the APB interface.
+    // This is drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/dap/constants.ts#L28
+    // Csw.CSW_VALUE = (CSW_RESERVED | CSW_MSTRDBG | CSW_HPROT | CSW_DBGSTAT | CSW_SADDRINC)
+    CSW_VALUE: (0x01000000 | 0x20000000 | 0x02000000 | 0x00000040 | 0x00000010),
+
+    // Represents the micro:bit's core registers
+    // Drawn from https://armmbed.github.io/dapjs/docs/enums/coreregister.html
+    CoreRegister: {
+        SP: 13,
+        LR: 14,
+        PC: 15
+    },
+
+    read32FromUInt8Array: function(data, i) {
+        return (data[i] | (data[i + 1] << 8) | (data[i + 2] << 16) | (data[i + 3] << 24)) >>> 0;
+    },
+
+    bufferConcat: function(bufs) {
+        let len = 0;
+        for (const b of bufs) {
+            len += b.length;
+        }
+        const r = new Uint8Array(len);
+        len = 0;
+        for (const b of bufs) {
+            r.set(b, len);
+            len += b.length;
+        }
+        return r;
+    },
+
+    // Returns the MurmurHash of the data passed to it, used for checksum calculation.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L14
+    murmur3_core: function(data) {
+        let h0 = 0x2F9BE6CC;
+        let h1 = 0x1EC3A6C8;
+
+        for (let i = 0; i < data.byteLength; i += 4) {
+            let k = this.read32FromUInt8Array(data, i) >>> 0;
+            k = Math.imul(k, 0xcc9e2d51);
+            k = (k << 15) | (k >>> 17);
+            k = Math.imul(k, 0x1b873593);
+
+            h0 ^= k;
+            h1 ^= k;
+            h0 = (h0 << 13) | (h0 >>> 19);
+            h1 = (h1 << 13) | (h1 >>> 19);
+            h0 = (Math.imul(h0, 5) + 0xe6546b64) >>> 0;
+            h1 = (Math.imul(h1, 5) + 0xe6546b64) >>> 0;
+        }
+        return [h0, h1]
+    },
+
+    // Returns a representation of an Access Port Register.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/util.ts#L63
+    apReg: function(r, mode) {
+        const v = r | mode | (1 << 0); // DapVal.AP_ACC;
+        return 4 + ((v & 0x0c) >> 2);
+    },
+
+    // Returns a code representing a request to read/write a certain register.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/util.ts#L92
+    regRequest: function(regId, isWrite = false) {
+        let request = !isWrite ? (1 << 1) /* READ */ : (0 << 1) /* WRITE */;
+
+        if (regId < 4) {
+            request |= (0 << 0) /* DP_ACC */;
+        } else {
+            request |= (1 << 0) /* AP_ACC */;
+        }
+
+        request |= (regId & 3) << 2;
+
+        return request;
+    },
+
+    // Split buffer into pages, each of pageSize size.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L209
+    pageAlignBlocks: function(buffer, targetAddr) {
+        class Page {
+            constructor(targetAddr, data) {
+                this.targetAddr = targetAddr;
+                this.data = data;
+            }
+        };
+
+        let unaligned = new Uint8Array(buffer);
+        let pages = [];
+        for (let i = 0; i < unaligned.byteLength;) {
+            let newbuf = new Uint8Array(this.pageSize);
+            let startPad = (targetAddr + i) & (this.pageSize - 1)
+            let newAddr = (targetAddr + i) - startPad
+            for (; i < unaligned.byteLength; ++i) {
+                if (targetAddr + i >= newAddr + this.pageSize)
+                    break
+                newbuf[targetAddr + i - newAddr] = unaligned[i];
+            }
+            let page = new Page(newAddr, newbuf);
+            pages.push(page);
+        }
+        return pages;
+    },
+
+    // Filter out all pages whose calculated checksum matches the corresponding checksum passed as an argument.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L523
+    onlyChanged: function(pages, checksums) {
+        return pages.filter(page => {
+            let idx = page.targetAddr / this.pageSize
+            if (idx * 8 + 8 > checksums.length)
+                return true // out of range?
+            let c0 = this.read32FromUInt8Array(checksums, idx * 8)
+            let c1 = this.read32FromUInt8Array(checksums, idx * 8 + 4)
+            let ch = this.murmur3_core(page.data)
+            if (c0 == ch[0] && c1 == ch[1])
+                return false
+            return true
+        })
+    }
+}
+
+class DAPWrapper {
+
+    constructor(device) {
+        this.reconnected = false;
+        this.flashing = true;
+        this.device = device;
+        this.allocDAP(device);
+    }
+
+    allocDAP() {
+        this.transport = new DAPjs.WebUSB(this.device);
+        this.daplink = new DAPjs.DAPLink(this.transport);
+        this.cortexM = new DAPjs.CortexM(this.transport);
+    }
+
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L119
+    reconnectAsync() {
+        let self = this;
+        let p = Promise.resolve();
+
+        // Only fully reconnect after the first time this object has reconnected.
+        if (!self.reconnected) {
+            self.reconnected = true;
+            p = p.then(() => self.allocDAP())
+                 .then(() => self.disconnectAsync());
+        }
+        return p
+            .then(() => self.daplink.connect())
+            .then(() => self.cortexM.connect());
+    }
+
+    disconnectAsync() {
+        let self = this;
+        if (self.device.opened && self.transport.interfaceNumber !== undefined) {
+            return self.daplink.disconnect();
+        }
+        return Promise.resolve();
+    }
+
+    // Send a packet to the micro:bit directly via WebUSB and return the response.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/transport/cmsis_dap.ts#L161
+    async send(packet) {
+        const array = Uint8Array.from(packet);
+        await this.transport.write(array.buffer);
+
+        const response = await this.transport.read();
+        return new Uint8Array(response.buffer);
+    }
+
+    // Send a command along with relevant data to the micro:bit directly via WebUSB and handle the response.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/transport/cmsis_dap.ts#L74
+    async cmdNums(op, data) {
+        data.unshift(op);
+
+        const buf = await this.send(data);
+
+        if (buf[0] !== op) {
+            throw new Error(`Bad response for ${op} -> ${buf[0]}`);
+        }
+
+        switch (op) {
+            case 0x02: // DapCmd.DAP_CONNECT:
+            case 0x00: // DapCmd.DAP_INFO:
+            case 0x05: // DapCmd.DAP_TRANSFER:
+            case 0x06: // DapCmd.DAP_TRANSFER_BLOCK:
+                break;
+            default:
+                if (buf[1] !== 0) {
+                    throw new Error(`Bad status for ${op} -> ${buf[1]}`);
+                }
+        }
+
+        return buf;
+    }
+
+    // Read a certain register a specified amount of times.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/dap/dap.ts#L117
+    async readRegRepeat(regId, cnt) {
+        const request = PartialFlashingUtils.regRequest(regId);
+        const sendargs = [0, cnt];
+
+        for (let i = 0; i < cnt; ++i) {
+            sendargs.push(request);
+        }
+
+        // Transfer the read requests to the micro:bit and retrieve the data read.
+        const buf = await this.cmdNums(0x05 /* DapCmd.DAP_TRANSFER */, sendargs);
+
+        if (buf[1] !== cnt) {
+            throw new Error(("(many) Bad #trans " + buf[1]));
+        } else if (buf[2] !== 1) {
+            throw new Error(("(many) Bad transfer status " + buf[2]));
+        }
+
+        return buf.subarray(3, 3 + cnt * 4);
+    }
+
+    // Write to a certain register a specified amount of data.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/dap/dap.ts#L138
+    async writeRegRepeat(regId, data) {
+        const request = PartialFlashingUtils.regRequest(regId, true);
+        const sendargs = [0, data.length, 0, request];
+
+        data.forEach((d) => {
+            // separate d into bytes
+            sendargs.push(d & 0xff, (d >> 8) & 0xff, (d >> 16) & 0xff, (d >> 24) & 0xff);
+        });
+
+        // Transfer the write requests to the micro:bit and retrieve the response status.
+        const buf = await this.cmdNums(0x06 /* DapCmd.DAP_TRANSFER */, sendargs);
+
+        if (buf[3] !== 1) {
+            throw new Error(("(many-wr) Bad transfer status " + buf[2]));
+        }
+    }
+
+    // Core functionality reading a block of data from micro:bit RAM at a specified address.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/memory/memory.ts#L181
+    async readBlockCore(addr, words) {
+        // Set up CMSIS-DAP to read/write from/to the RAM address addr using the register ApReg.DRW to write to or read from.
+        await this.cortexM.writeAP(0x00 /* ApReg.CSW */, PartialFlashingUtils.CSW_VALUE /* Csw.CSW_VALUE */ | 0x00000002 /* Csw.CSW_SIZE32 */);
+        await this.cortexM.writeAP(0x04 /* ApReg.TAR */, addr);
+
+        let lastSize = words % 15;
+        if (lastSize === 0) {
+            lastSize = 15;
+        }
+
+        const blocks = [];
+
+        for (let i = 0; i < Math.ceil(words / 15); i++) {
+            const b = await this.readRegRepeat(
+                PartialFlashingUtils.apReg(0x0C /* ApReg.DRW */, 1 << 1 /* DapVal.READ */),
+                i === blocks.length - 1 ? lastSize : 15,
+            );
+            blocks.push(b);
+        }
+
+        return PartialFlashingUtils.bufferConcat(blocks).subarray(0, words * 4);
+    }
+
+    // Core functionality writing a block of data to micro:bit RAM at a specified address.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/memory/memory.ts#L205
+    async writeBlockCore(addr, words) {
+        try {
+            // Set up CMSIS-DAP to read/write from/to the RAM address addr using the register ApReg.DRW to write to or read from.
+            await this.cortexM.writeAP(0x00 /* ApReg.CSW */, PartialFlashingUtils.CSW_VALUE /* Csw.CSW_VALUE */ | 0x00000002 /* Csw.CSW_SIZE32 */);
+            await this.cortexM.writeAP(0x04 /* ApReg.TAR */, addr);
+
+            await this.writeRegRepeat(PartialFlashingUtils.apReg(0x0C /* ApReg.DRW */, 0 << 1 /* DapVal.WRITE */), words)
+        } catch (e) {
+            if (e.dapWait) {
+                // Retry after a delay if required.
+                PartialFlashingUtils.log(`transfer wait, write block`);
+                await delay(100);
+                return await this.writeBlockCore(addr, words);
+            } else {
+                throw e;
+            }
+        }
+    }
+
+    // Reads a block of data from micro:bit RAM at a specified address.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/memory/memory.ts#L143
+    async readBlockAsync(addr, words) {
+        const bufs = [];
+        const end = addr + words * 4;
+        let ptr = addr;
+
+        // Read a single page at a time.
+        while (ptr < end) {
+            let nextptr = ptr + PartialFlashingUtils.pageSize;
+            if (ptr === addr) {
+                nextptr &= ~(PartialFlashingUtils.pageSize - 1);
+            }
+            const len = Math.min(nextptr - ptr, end - ptr);
+            bufs.push(await this.readBlockCore(ptr, len >> 2));
+            ptr = nextptr;
+        }
+        const result = PartialFlashingUtils.bufferConcat(bufs);
+        return result.subarray(0, words * 4);
+    }
+
+    // Writes a block of data to micro:bit RAM at a specified address.
+    async writeBlockAsync(address, data) {
+        let payloadSize = this.transport.packetSize - 8;
+        if (data.buffer.byteLength > payloadSize) {
+            let start = 0;
+            let end = payloadSize;
+
+            // Split write up into smaller writes whose data can each be held in a single packet.
+            while (start != end) {
+                let temp = new Uint32Array(data.buffer.slice(start, end))
+                await this.writeBlockCore(address + start, temp);
+
+                start = end;
+                end = Math.min(data.buffer.byteLength, end + payloadSize);
+            }
+        }
+        else {
+            await this.writeBlockCore(address, data);
+        }
+    }
+
+    // Execute code at a certain address with specified values in the registers.
+    // Waits for execution to halt.
+    async executeAsync(address, code, sp, pc, lr) {
+        if (arguments.length > 17) {
+            return Promise.resolve();
+        }
+
+        await this.cortexM.halt(true)
+            .then(() => this.writeBlockAsync(address, code))
+            .then(() => this.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.PC, pc))
+            .then(() => this.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.LR, lr))
+            .then(() => this.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.SP, sp))
+
+        for (let i = 5; i < arguments.length; ++i) {
+            await this.cortexM.writeCoreRegister(i - 5, arguments[i]);
+        }
+
+        return Promise.resolve().then(() => this.cortexM.resume(true))
+            .then(() => this.waitForHalt());
+    }
+
+    // Checks whether the micro:bit has halted or timeout has been reached.
+    // Recurses otherwise.
+    async waitForHaltCore(halted, timeout) {
+        let self = this;
+        if (new Date().getTime() > timeout) {
+            return Promise.reject(PartialFlashingUtils.timeoutMessage);
+        }
+        if (halted) {
+            return Promise.resolve();
+        }
+        else {
+            return this.cortexM.isHalted().then(a => self.waitForHaltCore(a, timeout));
+        }
+    }
+
+    // Initial function to call to wait for the micro:bit halt.
+    async waitForHalt(timeToWait = 10000) {
+        return this.waitForHaltCore(false, new Date().getTime() + timeToWait);
+    }
+
+    // Resets the micro:bit in software by writing to NVIC_AIRCR.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/cortex/cortex.ts#L347
+    async softwareReset() {
+        await this.cortexM.writeMem32(3758157068 /* NVIC_AIRCR */, 100270080 /* NVIC_AIRCR_VECTKEY */ | 4 /* NVIC_AIRCR_SYSRESETREQ */);
+
+        // wait for the system to come out of reset
+        let dhcsr = await this.cortexM.readMem32(3758157296 /* DHCSR */);
+
+        while ((dhcsr & 33554432 /* S_RESET_ST */) !== 0) {
+            dhcsr = await this.cortexM.readMem32(3758157296 /* DHCSR */);
+        }
+    }
+
+    // Reset the micro:bit, possibly halting the core on reset.
+    // Drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/cortex/cortex.ts#L248
+    async reset(halt = false) {
+        if (halt) {
+            await this.cortexM.halt(true);
+
+            let demcrAddr = 3758157308;
+
+            // VC_CORERESET causes the core to halt on reset.
+            const demcr = await this.cortexM.readMem32(demcrAddr);
+            await this.cortexM.writeMem32(demcrAddr, demcr | 1 /* DEMCR_VC_CORERESET */);
+
+            await this.softwareReset();
+            await this.waitForHalt();
+
+            // Unset the VC_CORERESET bit
+            await this.cortexM.writeMem32(demcrAddr, demcr);
+        } else {
+            await this.softwareReset();
+        }
+    }
+}
+
+let PartialFlashing = {
+
+    // Source code for binaries in can be found at https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/external/sha/source/main.c
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L243
+    flashPageBIN: new Uint32Array([
+        0xbe00be00, // bkpt - LR is set to this
+        0x2402b5f0, 0x4a174b16, 0x2480509c, 0x002500e4, 0x2e00591e, 0x24a1d0fc,
+        0x511800e4, 0x2c00595c, 0x2400d0fc, 0x2480509c, 0x002500e4, 0x2e00591e,
+        0x2401d0fc, 0x595c509c, 0xd0fc2c00, 0x00ed2580, 0x002e2400, 0x5107590f,
+        0x2f00595f, 0x3404d0fc, 0xd1f742ac, 0x50992100, 0x2a00599a, 0xbdf0d0fc,
+        0x4001e000, 0x00000504,
+    ]),
+
+    // void computeHashes(uint32_t *dst, uint8_t *ptr, uint32_t pageSize, uint32_t numPages)
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L253
+    computeChecksums2: new Uint32Array([
+        0x4c27b5f0, 0x44a52680, 0x22009201, 0x91004f25, 0x00769303, 0x24080013,
+        0x25010019, 0x40eb4029, 0xd0002900, 0x3c01407b, 0xd1f52c00, 0x468c0091,
+        0xa9044665, 0x506b3201, 0xd1eb42b2, 0x089b9b01, 0x23139302, 0x9b03469c,
+        0xd104429c, 0x2000be2a, 0x449d4b15, 0x9f00bdf0, 0x4d149e02, 0x49154a14,
+        0x3e01cf08, 0x2111434b, 0x491341cb, 0x405a434b, 0x4663405d, 0x230541da,
+        0x4b10435a, 0x466318d2, 0x230541dd, 0x4b0d435d, 0x2e0018ed, 0x6002d1e7,
+        0x9a009b01, 0x18d36045, 0x93003008, 0xe7d23401, 0xfffffbec, 0xedb88320,
+        0x00000414, 0x1ec3a6c8, 0x2f9be6cc, 0xcc9e2d51, 0x1b873593, 0xe6546b64,
+    ]),
+
+    membase: 0x20000000,
+    loadAddr: 0x20000000,
+    dataAddr: 0x20002000,
+    stackAddr: 0x20001000,
+
+    // Returns a new DAPWrapper or reconnects a previously used one.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L161
+    dapAsync: function() {
+        if (window.previousDapWrapper) {
+            if (window.previousDapWrapper.device.opened) {
+                return window.previousDapWrapper.reconnectAsync(false) // Always fully reconnect to handle device unplugged mid-session
+                    .then(() => window.previousDapWrapper);
+            }
+        }
+        return Promise.resolve()
+            .then(() => {
+                if (window.previousDapWrapper) {
+                    return window.previousDapWrapper.disconnectAsync()
+                        .finally(() => {
+                                window.previousDapWrapper = null;
+                            });
+                }
+                return Promise.resolve();
+            })
+            .then(() => navigator.usb.requestDevice({ filters: [{vendorId: 0x0d28, productId: 0x0204}] }))
+            .then(device => {
+                let w = new DAPWrapper(device);
+                window.previousDapWrapper = w;
+                return w.reconnectAsync(true)
+                    .then(() => {
+                        return w
+                    })
+            })
+    },
+
+    // Runs the checksum algorithm on the micro:bit's whole flash memory, and returns the results.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L365
+    getFlashChecksumsAsync: function(dapwrapper) {
+        return dapwrapper.executeAsync(this.loadAddr, this.computeChecksums2, this.stackAddr, this.loadAddr + 1, 0xffffffff,
+                                      this.dataAddr, 0, PartialFlashingUtils.pageSize, PartialFlashingUtils.numPages)
+            .then(() => {
+                return dapwrapper.readBlockAsync(this.dataAddr, PartialFlashingUtils.numPages * 2);
+            });
+    },
+
+    // Runs the code on the micro:bit to copy a single page of data from RAM address addr to the ROM address specified by the page.
+    // Does not wait for execution to halt.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L340
+    runFlash: async function(page, addr) {
+        await dapwrapper.cortexM.halt(true);
+        return Promise.all([dapwrapper.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.PC, this.loadAddr + 4 + 1),
+              dapwrapper.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.LR, this.loadAddr + 1),
+              dapwrapper.cortexM.writeCoreRegister(PartialFlashingUtils.CoreRegister.SP, this.stackAddr),
+              dapwrapper.cortexM.writeCoreRegister(0, page.targetAddr),
+              dapwrapper.cortexM.writeCoreRegister(1, addr)])
+            .then(() => dapwrapper.cortexM.resume(false));
+    },
+
+    // Write a single page of data to micro:bit ROM by writing it to micro:bit RAM and copying to ROM.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L385
+    partialFlashPageAsync: function(dapwrapper, page, nextPage, i) {
+        if (page.targetAddr >= 0x10000000)
+            return Promise.resolve();
+
+        let writeBl = Promise.resolve();
+
+        // Use two slots in RAM to allow parallelisation of the following two tasks.
+        // 1. DAPjs writes a page to one slot.
+        // 2. flashPageBIN copies a page to flash from the other slot.
+        let thisAddr = (i & 1) ? this.dataAddr : this.dataAddr + PartialFlashingUtils.pageSize;
+        let nextAddr = (i & 1) ? this.dataAddr + PartialFlashingUtils.pageSize : this.dataAddr;
+
+        // Write first page to slot in RAM.
+        // All subsequent pages will have already been written to RAM.
+        if (i == 0) {
+            let u32data = new Uint32Array(page.data.length / 4);
+            for (let i = 0; i < page.data.length; i += 4)
+                u32data[i >> 2] = PartialFlashingUtils.read32FromUInt8Array(page.data, i);
+            writeBl = dapwrapper.writeBlockAsync(thisAddr, u32data);
+        }
+
+        return writeBl
+            .then(() => this.runFlash(page, thisAddr))
+            .then(() => {
+                if (!nextPage)
+                    return Promise.resolve();
+                // Write next page to micro:bit RAM if it exists.
+                let buf = new Uint32Array(nextPage.data.buffer);
+                return dapwrapper.writeBlockAsync(nextAddr, buf);
+            })
+            .then(() => dapwrapper.waitForHalt());
+    },
+
+    // Write pages of data to micro:bit ROM.
+    partialFlashCoreAsync: async function(dapwrapper, pages, updateProgress) {
+        PartialFlashingUtils.log("Partial flash");
+        let startTime = new Date().getTime();
+        for (let i = 0; i < pages.length; ++i) {
+            if (i != 0) {
+                let progress = (i / pages.length) * 100;
+                // let currentTime = new Date().getTime();
+                // let rate = (currentTime - startTime) / progress;
+                // let remaining = rate * (100 - progress);
+                // PartialFlashingUtils.log("Time: " + Math.floor((currentTime - startTime) / (1000 * 60)) + " minutes");
+                // PartialFlashingUtils.log("Rate: " + Math.ceil(rate) + "ms per page");
+                // PartialFlashingUtils.log("Progress: " + Math.floor(progress) + "%");
+                // PartialFlashingUtils.log(Math.ceil(remaining / (1000 * 60)) + " minute(s) remaining");
+                updateProgress(progress);
+            }
+            await this.partialFlashPageAsync(dapwrapper, pages[i], pages[i+1], i);
+        }
+        updateProgress(1);
+    },
+
+    // Flash the micro:bit's ROM with the provided image by only copying over the pages that differ.
+    // Falls back to a full flash if partial flashing fails.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L335
+    partialFlashAsync: async function(dapwrapper, image, updateProgress) {
+        let checksums;
+        return this.getFlashChecksumsAsync(dapwrapper)
+            .then(buf => {
+                checksums = buf;
+                // Write binary to RAM, ready for execution.
+                return dapwrapper.writeBlockAsync(this.loadAddr, this.flashPageBIN);
+            })
+            .then(async () => {
+                let aligned = PartialFlashingUtils.pageAlignBlocks(image, 0);
+                PartialFlashingUtils.log("Total pages: " + aligned.length);
+                aligned = PartialFlashingUtils.onlyChanged(aligned, checksums);
+                PartialFlashingUtils.log("Changed pages: " + aligned.length);
+
+                if (aligned.length > 100) {
+                    try {
+                        await this.fullFlashAsync(dapwrapper, image);
+                    } catch {
+                        PartialFlashingUtils.log(`Full flash failed, attempting partial flash.`);
+                        await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
+                    }
+                }
+                else {
+                    try {
+                        await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
+                    } catch {
+                        PartialFlashingUtils.log(`Partial flash failed, attempting full flash.`);
+                        await this.fullFlashAsync(dapwrapper, image);
+                    }
+                }
+
+                return Promise.resolve()
+                    .then(() => dapwrapper.reset())
+                    // Allow errors on resetting, user can always manually reset if necessary.
+                    .catch(() => {})
+                    .then(() => {
+                        PartialFlashingUtils.log("Flashing Complete");
+                        dapwrapper.flashing = false;
+                    });
+            })
+    },
+
+    // Perform full flash of micro:bit's ROM using daplink.
+    fullFlashAsync: function(dapwrapper, image) {
+        PartialFlashingUtils.log("Full flash");
+        // Event to monitor flashing progress
+        dapwrapper.daplink.on(DAPjs.DAPLink.EVENT_PROGRESS, function(progress) {
+            $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
+        });
+        return dapwrapper.daplink.flash(image);
+    },
+
+    // Connect to the micro:bit using WebUSB and setup DAPWrapper.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L439
+    connectDapAsync: function() {
+        return Promise.resolve()
+            .then(() => {
+                if (window.previousDapWrapper) {
+                    window.previousDapWrapper.flashing = true;
+                    return Promise.resolve()
+                        .then(() => new Promise(resolve => setTimeout(resolve, 1000)));
+                }
+                return Promise.resolve();
+            })
+            .then(this.dapAsync)
+            .then(w => {
+                window.dapwrapper = w;
+                PartialFlashingUtils.log("Connection Complete");
+            });
+    },
+
+    // Flash the micro:bit's ROM with the provided image, resetting the micro:bit first.
+    // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L439
+    flashAsync: async function(dapwrapper, image, updateProgress) {
+        try {
+            let p = Promise.resolve()
+                .then(() => {
+                    // Reset micro:bit to ensure interface responds correctly.
+                    PartialFlashingUtils.log("Begin reset");
+                    return dapwrapper.reset(true)
+                        .catch(e => {
+                            PartialFlashingUtils.log("Retrying reset");
+                            return dapwrapper.reconnectAsync(false)
+                                .then(() => dapwrapper.reset(true));
+                        });
+                });
+
+            let timeout = new Promise((resolve, reject) => {
+                setTimeout(() => {
+                    PartialFlashingUtils.log("Resetting micro:bit timed out");
+                    reject('Timeout')
+                }, 1000)
+            })
+
+            // Use race to timeout the reset.
+            let ret = await Promise.race([p, timeout])
+            .then(() => {
+                PartialFlashingUtils.log("Begin Flashing");
+                return this.partialFlashAsync(dapwrapper, image, updateProgress);
+            });
+            return ret;
+        } catch (err) {
+            // Fall back to full flash if attempting to reset times out.
+            if (err === "Timeout") {
+                return this.fullFlashAsync(dapwrapper, image);
+            }
+            return Promise.reject(err);
+        }
+    }
+}

--- a/python-main.js
+++ b/python-main.js
@@ -191,7 +191,7 @@ function blocks() {
 
     var blocklyWrapper = {};
     var resizeSensorInstance = null;
-    // Stores the Blockly workspace created during injection 
+    // Stores the Blockly workspace created during injection
     var workspace = null;
 
     blocklyWrapper.init = function() {
@@ -338,6 +338,8 @@ function web_editor(config) {
     // Indicates if there are unsaved changes to the content of the editor.
     var dirty = false;
 
+    var usePartialFlashing = true;
+
     // MicroPython filesystem to be initialised on page load.
     window.micropythonFs = undefined;
 
@@ -439,7 +441,9 @@ function web_editor(config) {
 
         if (navigator.usb) {
             script('static/js/dap.umd.js');
+            script('static/js/intel-hex.browser.js');
             script('static/js/hterm_all.js');
+            script('partial-flashing.js');
             $("#command-connect").removeClass('hidden');
             $("#command-serial").removeClass('hidden');
         }
@@ -1044,58 +1048,57 @@ function web_editor(config) {
     }
 
     function doConnect(e, serial) {
-        navigator.usb.requestDevice({
-            filters: [{vendorId: 0x0d28, productId: 0x0204}]
-        }).then(function(device) {
-            // Connect to device
-            window.transport = new DAPjs.WebUSB(device);
-            window.daplink = new DAPjs.DAPLink(window.transport);
+        var p = Promise.resolve();
 
-            // Ensure disconnected
-            window.daplink.disconnect();
+        if (usePartialFlashing) {
+            p = PartialFlashing.connectDapAsync();
+        }
+        else {
+            p = navigator.usb.requestDevice({
+                filters: [{vendorId: 0x0d28, productId: 0x0204}]
+            }).then(function(device) {
+                // Connect to device
+                window.transport = new DAPjs.WebUSB(device);
+                window.daplink = new DAPjs.DAPLink(window.transport);
 
-            // Connect to board
-            return window.daplink.connect()
-            .then(function() {
-                try {
-                 var output = generateFullHexStr();
-               } catch(err) {
-                 alert(err.message);
-                 return;
-                }
+                // Ensure disconnected
+                window.daplink.disconnect();
 
-                // Change button to disconnect
-                $("#command-connect").attr("id", "command-disconnect");
-                $("#command-disconnect > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-disconnect"]["label"]);
-                $("#command-disconnect").attr("title", config["translate"]["static-strings"]["buttons"]["command-disconnect"]["title"]);
-
-                // Change download to flash
-                $("#command-download").attr("id", "command-flash");
-                $("#command-flash > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-flash"]["label"]);
-                $("#command-flash").attr("title", config["translate"]["static-strings"]["buttons"]["command-flash"]["title"]);
-
-                if (serial){
-                  doSerial();
-                }
-            })
-            .catch(function(err) {
-                console.log("Error connecting: " + err);
-                $("#flashing-overlay-container").css("display", "flex");
-                $("#flashing-info").addClass('hidden');
-
-                // If micro:bit does not support dapjs
-                if (err.message === "No valid interfaces found."){
-                    $("#flashing-overlay-error").html('<div>' + err + '</div><div>'+ config["translate"]["webusb"]["err"]["update-req"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
-                    return;
-                } else if (err.message === "Unable to claim interface.") {
-                    $("#flashing-overlay-error").html('<div>'+ config["translate"]["webusb"]["err"]["clear-connect"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
-                    return;
-                }
-
-                $("#flashing-overlay-error").html('<div>' + err + '</div><div>'+ config["translate"]["webusb"]["err"]["restart-microbit"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
+                // Connect to board
+                return window.daplink.connect();
             });
-        }).catch(function(err) {
-            console.log("There was an error during connecting: " + err);
+        }
+
+        return p.then(function() {
+            // Change button to disconnect
+            $("#command-connect").attr("id", "command-disconnect");
+            $("#command-disconnect > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-disconnect"]["label"]);
+            $("#command-disconnect").attr("title", config["translate"]["static-strings"]["buttons"]["command-disconnect"]["title"]);
+
+            // Change download to flash
+            $("#command-download").attr("id", "command-flash");
+            $("#command-flash > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-flash"]["label"]);
+            $("#command-flash").attr("title", config["translate"]["static-strings"]["buttons"]["command-flash"]["title"]);
+
+            if (serial){
+              doSerial();
+            }
+        })
+        .catch(function(err) {
+            console.log("Error connecting: " + err);
+            $("#flashing-overlay-container").css("display", "flex");
+            $("#flashing-info").addClass('hidden');
+
+            // If micro:bit does not support dapjs
+            if (err.message === "No valid interfaces found."){
+                $("#flashing-overlay-error").html('<div>' + err + '</div><div>'+ config["translate"]["webusb"]["err"]["update-req"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
+                return;
+            } else if (err.message === "Unable to claim interface.") {
+                $("#flashing-overlay-error").html('<div>'+ config["translate"]["webusb"]["err"]["clear-connect"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
+                return;
+            }
+
+            $("#flashing-overlay-error").html('<div>' + err + '</div><div>'+ config["translate"]["webusb"]["err"]["restart-microbit"] +'</div><a href="#" onclick="flashErrorClose()">'+ config["translate"]["webusb"]["close"] +'</a>');
         });
     }
 
@@ -1109,11 +1112,8 @@ function web_editor(config) {
             $("#command-serial > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-serial"]["label"]);
         }
 
-        window.daplink.stopSerialRead();
         $("#repl").empty();
         REPL = null;
-
-        window.daplink.disconnect();
 
         // Change button to connect
         $("#command-disconnect").attr("id", "command-connect");
@@ -1124,47 +1124,94 @@ function web_editor(config) {
         $("#command-flash").attr("id", "command-download");
         $("#command-download > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-download"]["label"]);
         $("#command-download").attr("title", config["translate"]["static-strings"]["buttons"]["command-download"]["title"]);
+
+        var p = Promise.resolve();
+
+        if (usePartialFlashing) {
+            if (window.dapwrapper) {
+                p = p.then(() => window.dapwrapper.daplink.stopSerialRead())
+                    .then(() => window.dapwrapper.disconnectAsync());
+            }
+        }
+        else {
+            if (window.daplink) {
+                p = p.then(() => window.daplink.stopSerialRead())
+                    .then(() => window.daplink.disconnect());
+            }
+        }
+        return p;
     }
 
     function doFlash(e) {
+        // var startTime = new Date().getTime();
+
         // Hide serial and disconnect if open
         if ($("#repl").css('display') != 'none') {
             $("#repl").hide();
             $("#request-repl").hide();
             $("#editor-container").show();
-            window.daplink.stopSerialRead();
             $("#command-serial").attr("title", config["translate"]["static-strings"]["buttons"]["command-serial"]["title"]);
             $("#command-serial > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-serial"]["label"]);
+
+            if (usePartialFlashing) {
+                if (window.dapwrapper) {
+                    window.dapwrapper.daplink.stopSerialRead();
+                }
+            }
+            else {
+                window.daplink.stopSerialRead();
+            }
         }
 
-        // Event to monitor flashing progress
-        window.daplink.on(DAPjs.DAPLink.EVENT_PROGRESS, function(progress) {
-            $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
-        });
+        var p = Promise.resolve();
 
-        // Push binary to board
-        return window.daplink.connect()
-        .then(function() {
-            try {
-             var output = generateFullHexStr();
-            } catch(error) {
-             alert(err.message);
-             return;
-            }
+        $("#webusb-flashing-progress").val(0);
+        $("#webusb-flashing-progress").val(0).css("display", "inline-block");
+        $('#flashing-overlay-error').html("");
+        $("#flashing-info").removeClass('hidden');
+        $("#flashing-overlay-container").css("display", "flex");
 
-            // Encode firmware for flashing
-            var enc = new TextEncoder();
-            var image = enc.encode(output).buffer;
+        if (usePartialFlashing) {
+            // Push binary to board
+            p = PartialFlashing.connectDapAsync()
+                .then(function() {
+                    var output = generateFullHexStr();
+                    var image = MemoryMap.fromHex(output).slicePad(0, PartialFlashingUtils.pageSize * PartialFlashingUtils.numPages);
 
-            $("#webusb-flashing-progress").val(0);
-            $('#flashing-overlay-error').html("");
-            $("#flashing-info").removeClass('hidden');
-            $("#flashing-overlay-container").css("display", "flex");
-            return window.daplink.flash(image);
-        })
-        .then(function() {
+                    var updateProgress = function(progress) {
+                        $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
+                    }
+                    return PartialFlashing.flashAsync(window.dapwrapper, image, updateProgress);
+                })
+        }
+        else {
+            // Push binary to board
+            p = window.daplink.connect()
+                .then(function() {
+                    // Event to monitor flashing progress
+                    window.daplink.on(DAPjs.DAPLink.EVENT_PROGRESS, function(progress) {
+                        $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
+                    });
+
+                    try {
+                     var output = generateFullHexStr();
+                    } catch(error) {
+                     alert(err.message);
+                     return;
+                    }
+
+                    // Encode firmware for flashing
+                    var enc = new TextEncoder();
+                    var image = enc.encode(output).buffer;
+                    return window.daplink.flash(image);
+                });
+        }
+
+        return p.then(function() {
             $("#flashing-overlay-container").hide();
-            return;
+            // var timeTaken = (new Date().getTime() - startTime) / (1000 * 60);
+            // console.log("Time taken to flash: " + Math.floor(timeTaken) + " minutes, "
+            //           + Math.ceil((timeTaken - Math.floor(timeTaken)) * 60) + " seconds");
         })
         .catch(function(err) {
             console.log("Error flashing: " + err);
@@ -1191,9 +1238,16 @@ function web_editor(config) {
             $("#repl").hide();
             $("#request-repl").hide();
             $("#editor-container").show();
-            window.daplink.stopSerialRead();
             $("#command-serial").attr("title", serialButton["label"]);
             $("#command-serial > .roundlabel").text(serialButton["label"]);
+            if (usePartialFlashing) {
+                if (window.dapwrapper) {
+                    window.dapwrapper.daplink.stopSerialRead();
+                }
+            }
+            else {
+                window.daplink.stopSerialRead();
+            }
             return;
         }
 
@@ -1205,15 +1259,17 @@ function web_editor(config) {
             $("#command-serial").attr("title", serialButton["title-close"]);
             $("#command-serial > .roundlabel").text(serialButton["label-close"]);
 
-            window.daplink.connect()
+            var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
+
+            daplink.connect()
             .then( function() {
-                return window.daplink.setSerialBaudrate(115200);
+                return daplink.setSerialBaudrate(115200);
             })
             .then( function() {
-                return window.daplink.getSerialBaudrate();
+                return daplink.getSerialBaudrate();
             })
             .then(function(baud) {
-                window.daplink.startSerialRead(50);
+                daplink.startSerialRead(50);
                 lib.init(setupHterm);
             })
             .catch(function(err) {
@@ -1242,10 +1298,12 @@ function web_editor(config) {
             REPL.onTerminalReady = function() {
                 var io = REPL.io.push();
                 io.onVTKeystroke = function(str) {
-                    window.daplink.serialWrite(str);
+                    var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
+                    daplink.serialWrite(str);
                 };
                 io.sendString = function(str) {
-                    window.daplink.serialWrite(str);
+                    var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
+                    daplink.serialWrite(str);
                 };
                 io.onTerminalResize = function(columns, rows) {
                 };
@@ -1253,8 +1311,9 @@ function web_editor(config) {
             REPL.decorate(document.querySelector('#repl'));
             REPL.installKeyboard();
 
-            window.daplink.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, function(data) {
-                    REPL.io.print(data); // first byte of data is length
+            var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
+            daplink.on(DAPjs.DAPLink.EVENT_SERIAL_DATA, function(data) {
+                REPL.io.print(data); // first byte of data is length
             });
         }
 
@@ -1376,6 +1435,15 @@ function web_editor(config) {
         $('#menu-switch-autocomplete-enter').on('change', function() {
             var setEnable = $(this).is(':checked');
             EDITOR.triggerAutocompleteWithEnter(setEnable);
+        });
+        $('#menu-switch-partial-flashing').on('change', function() {
+            var setEnable = $(this).is(':checked');
+            return doDisconnect()
+                .catch(err => {
+                    // Assume an error means that it is already disconnected.
+                    // console.log("Error disconnecting when " + (setEnable ? "not " : "") + "using partial flashing: \r\n" + err);
+                })
+                .then(() => usePartialFlashing = setEnable)
         });
 
         window.addEventListener('resize', function() {

--- a/static/js/intel-hex.browser.js
+++ b/static/js/intel-hex.browser.js
@@ -1,0 +1,1249 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global.MemoryMap = factory());
+}(this, (function () { 'use strict';
+
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+/**
+ * Parser/writer for the "Intel hex" format.
+ */
+
+/*
+ * A regexp that matches lines in a .hex file.
+ *
+ * One hexadecimal character is matched by "[0-9A-Fa-f]".
+ * Two hex characters are matched by "[0-9A-Fa-f]{2}"
+ * Eight or more hex characters are matched by "[0-9A-Fa-f]{8,}"
+ * A capture group of two hex characters is "([0-9A-Fa-f]{2})"
+ *
+ * Record mark         :
+ * 8 or more hex chars  ([0-9A-Fa-f]{8,})
+ * Checksum                              ([0-9A-Fa-f]{2})
+ * Optional newline                                      (?:\r\n|\r|\n|)
+ */
+var hexLineRegexp = /:([0-9A-Fa-f]{8,})([0-9A-Fa-f]{2})(?:\r\n|\r|\n|)/g;
+
+// Takes a Uint8Array as input,
+// Returns an integer in the 0-255 range.
+function checksum(bytes) {
+    return -bytes.reduce(function (sum, v) {
+        return sum + v;
+    }, 0) & 0xFF;
+}
+
+// Takes two Uint8Arrays as input,
+// Returns an integer in the 0-255 range.
+function checksumTwo(array1, array2) {
+    var partial1 = array1.reduce(function (sum, v) {
+        return sum + v;
+    }, 0);
+    var partial2 = array2.reduce(function (sum, v) {
+        return sum + v;
+    }, 0);
+    return -(partial1 + partial2) & 0xFF;
+}
+
+// Trivial utility. Converts a number to hex and pads with zeroes up to 2 characters.
+function hexpad(number) {
+    return number.toString(16).toUpperCase().padStart(2, '0');
+}
+
+// Polyfill as per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
+Number.isInteger = Number.isInteger || function (value) {
+    return typeof value === 'number' && isFinite(value) && Math.floor(value) === value;
+};
+
+/**
+ * @class MemoryMap
+ *
+ * Represents the contents of a memory layout, with main focus into (possibly sparse) blocks of data.
+ *<br/>
+ * A {@linkcode MemoryMap} acts as a subclass of
+ * {@linkcode https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map|Map}.
+ * In every entry of it, the key is the starting address of a data block (an integer number),
+ * and the value is the <tt>Uint8Array</tt> with the data for that block.
+ *<br/>
+ * The main rationale for this is that a .hex file can contain a single block of contiguous
+ * data starting at memory address 0 (and it's the common case for simple .hex files),
+ * but complex files with several non-contiguous data blocks are also possible, thus
+ * the need for a data structure on top of the <tt>Uint8Array</tt>s.
+ *<br/>
+ * In order to parse <tt>.hex</tt> files, use the {@linkcode MemoryMap.fromHex} <em>static</em> factory
+ * method. In order to write <tt>.hex</tt> files, create a new {@linkcode MemoryMap} and call
+ * its {@linkcode MemoryMap.asHexString} method.
+ *
+ * @extends Map
+ * @example
+ * import MemoryMap from 'nrf-intel-hex';
+ *
+ * let memMap1 = new MemoryMap();
+ * let memMap2 = new MemoryMap([[0, new Uint8Array(1,2,3,4)]]);
+ * let memMap3 = new MemoryMap({0: new Uint8Array(1,2,3,4)});
+ * let memMap4 = new MemoryMap({0xCF0: new Uint8Array(1,2,3,4)});
+ */
+
+var MemoryMap = function () {
+    /**
+     * @param {Iterable} blocks The initial value for the memory blocks inside this
+     * <tt>MemoryMap</tt>. All keys must be numeric, and all values must be instances of
+     * <tt>Uint8Array</tt>. Optionally it can also be a plain <tt>Object</tt> with
+     * only numeric keys.
+     */
+    function MemoryMap(blocks) {
+        _classCallCheck(this, MemoryMap);
+
+        this._blocks = new Map();
+
+        if (blocks && typeof blocks[Symbol.iterator] === 'function') {
+            var _iteratorNormalCompletion = true;
+            var _didIteratorError = false;
+            var _iteratorError = undefined;
+
+            try {
+                for (var _iterator = blocks[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                    var tuple = _step.value;
+
+                    if (!(tuple instanceof Array) || tuple.length !== 2) {
+                        throw new Error('First parameter to MemoryMap constructor must be an iterable of [addr, bytes] or undefined');
+                    }
+                    this.set(tuple[0], tuple[1]);
+                }
+            } catch (err) {
+                _didIteratorError = true;
+                _iteratorError = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion && _iterator.return) {
+                        _iterator.return();
+                    }
+                } finally {
+                    if (_didIteratorError) {
+                        throw _iteratorError;
+                    }
+                }
+            }
+        } else if ((typeof blocks === 'undefined' ? 'undefined' : _typeof(blocks)) === 'object') {
+            // Try iterating through the object's keys
+            var addrs = Object.keys(blocks);
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
+
+            try {
+                for (var _iterator2 = addrs[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                    var addr = _step2.value;
+
+                    this.set(parseInt(addr), blocks[addr]);
+                }
+            } catch (err) {
+                _didIteratorError2 = true;
+                _iteratorError2 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                        _iterator2.return();
+                    }
+                } finally {
+                    if (_didIteratorError2) {
+                        throw _iteratorError2;
+                    }
+                }
+            }
+        } else if (blocks !== undefined && blocks !== null) {
+            throw new Error('First parameter to MemoryMap constructor must be an iterable of [addr, bytes] or undefined');
+        }
+    }
+
+    _createClass(MemoryMap, [{
+        key: 'set',
+        value: function set(addr, value) {
+            if (!Number.isInteger(addr)) {
+                throw new Error('Address passed to MemoryMap is not an integer');
+            }
+            if (addr < 0) {
+                throw new Error('Address passed to MemoryMap is negative');
+            }
+            if (!(value instanceof Uint8Array)) {
+                throw new Error('Bytes passed to MemoryMap are not an Uint8Array');
+            }
+            return this._blocks.set(addr, value);
+        }
+        // Delegate the following to the 'this._blocks' Map:
+
+    }, {
+        key: 'get',
+        value: function get(addr) {
+            return this._blocks.get(addr);
+        }
+    }, {
+        key: 'clear',
+        value: function clear() {
+            return this._blocks.clear();
+        }
+    }, {
+        key: 'delete',
+        value: function _delete(addr) {
+            return this._blocks.delete(addr);
+        }
+    }, {
+        key: 'entries',
+        value: function entries() {
+            return this._blocks.entries();
+        }
+    }, {
+        key: 'forEach',
+        value: function forEach(callback, that) {
+            return this._blocks.forEach(callback, that);
+        }
+    }, {
+        key: 'has',
+        value: function has(addr) {
+            return this._blocks.has(addr);
+        }
+    }, {
+        key: 'keys',
+        value: function keys() {
+            return this._blocks.keys();
+        }
+    }, {
+        key: 'values',
+        value: function values() {
+            return this._blocks.values();
+        }
+    }, {
+        key: Symbol.iterator,
+        value: function value() {
+            return this._blocks[Symbol.iterator]();
+        }
+
+        /**
+         * Parses a string containing data formatted in "Intel HEX" format, and
+         * returns an instance of {@linkcode MemoryMap}.
+         *<br/>
+         * The insertion order of keys in the {@linkcode MemoryMap} is guaranteed to be strictly
+         * ascending. In other words, when iterating through the {@linkcode MemoryMap}, the addresses
+         * will be ordered in ascending order.
+         *<br/>
+         * The parser has an opinionated behaviour, and will throw a descriptive error if it
+         * encounters some malformed input. Check the project's
+         * {@link https://github.com/NordicSemiconductor/nrf-intel-hex#Features|README file} for details.
+         *<br/>
+         * If <tt>maxBlockSize</tt> is given, any contiguous data block larger than that will
+         * be split in several blocks.
+         *
+         * @param {String} hexText The contents of a .hex file.
+         * @param {Number} [maxBlockSize=Infinity] Maximum size of the returned <tt>Uint8Array</tt>s.
+         *
+         * @return {MemoryMap}
+         *
+         * @example
+         * import MemoryMap from 'nrf-intel-hex';
+         *
+         * let intelHexString =
+         *     ":100000000102030405060708090A0B0C0D0E0F1068\n" +
+         *     ":00000001FF";
+         *
+         * let memMap = MemoryMap.fromHex(intelHexString);
+         *
+         * for (let [address, dataBlock] of memMap) {
+         *     console.log('Data block at ', address, ', bytes: ', dataBlock);
+         * }
+         */
+
+    }, {
+        key: 'join',
+
+
+        /**
+         * Returns a <strong>new</strong> instance of {@linkcode MemoryMap}, containing
+         * the same data, but concatenating together those memory blocks that are adjacent.
+         *<br/>
+         * The insertion order of keys in the {@linkcode MemoryMap} is guaranteed to be strictly
+         * ascending. In other words, when iterating through the {@linkcode MemoryMap}, the addresses
+         * will be ordered in ascending order.
+         *<br/>
+         * If <tt>maxBlockSize</tt> is given, blocks will be concatenated together only
+         * until the joined block reaches this size in bytes. This means that the output
+         * {@linkcode MemoryMap} might have more entries than the input one.
+         *<br/>
+         * If there is any overlap between blocks, an error will be thrown.
+         *<br/>
+         * The returned {@linkcode MemoryMap} will use newly allocated memory.
+         *
+         * @param {Number} [maxBlockSize=Infinity] Maximum size of the <tt>Uint8Array</tt>s in the
+         * returned {@linkcode MemoryMap}.
+         *
+         * @return {MemoryMap}
+         */
+        value: function join() {
+            var maxBlockSize = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : Infinity;
+
+
+            // First pass, create a Map of address→length of contiguous blocks
+            var sortedKeys = Array.from(this.keys()).sort(function (a, b) {
+                return a - b;
+            });
+            var blockSizes = new Map();
+            var lastBlockAddr = -1;
+            var lastBlockEndAddr = -1;
+
+            for (var i = 0, l = sortedKeys.length; i < l; i++) {
+                var blockAddr = sortedKeys[i];
+                var blockLength = this.get(sortedKeys[i]).length;
+
+                if (lastBlockEndAddr === blockAddr && lastBlockEndAddr - lastBlockAddr < maxBlockSize) {
+                    // Grow when the previous end address equals the current,
+                    // and we don't go over the maximum block size.
+                    blockSizes.set(lastBlockAddr, blockSizes.get(lastBlockAddr) + blockLength);
+                    lastBlockEndAddr += blockLength;
+                } else if (lastBlockEndAddr <= blockAddr) {
+                    // Else mark a new block.
+                    blockSizes.set(blockAddr, blockLength);
+                    lastBlockAddr = blockAddr;
+                    lastBlockEndAddr = blockAddr + blockLength;
+                } else {
+                    throw new Error('Overlapping data around address 0x' + blockAddr.toString(16));
+                }
+            }
+
+            // Second pass: allocate memory for the contiguous blocks and copy data around.
+            var mergedBlocks = new MemoryMap();
+            var mergingBlock = void 0;
+            var mergingBlockAddr = -1;
+            for (var _i = 0, _l = sortedKeys.length; _i < _l; _i++) {
+                var _blockAddr = sortedKeys[_i];
+                if (blockSizes.has(_blockAddr)) {
+                    mergingBlock = new Uint8Array(blockSizes.get(_blockAddr));
+                    mergedBlocks.set(_blockAddr, mergingBlock);
+                    mergingBlockAddr = _blockAddr;
+                }
+                mergingBlock.set(this.get(_blockAddr), _blockAddr - mergingBlockAddr);
+            }
+
+            return mergedBlocks;
+        }
+
+        /**
+         * Given a {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Map|<tt>Map</tt>}
+         * of {@linkcode MemoryMap}s, indexed by a alphanumeric ID,
+         * returns a <tt>Map</tt> of address to tuples (<tt>Arrays</tt>s of length 2) of the form
+         * <tt>(id, Uint8Array)</tt>s.
+         *<br/>
+         * The scenario for using this is having several {@linkcode MemoryMap}s, from several calls to
+         * {@link module:nrf-intel-hex~hexToArrays|hexToArrays}, each having a different identifier.
+         * This function locates where those memory block sets overlap, and returns a <tt>Map</tt>
+         * containing addresses as keys, and arrays as values. Each array will contain 1 or more
+         * <tt>(id, Uint8Array)</tt> tuples: the identifier of the memory block set that has
+         * data in that region, and the data itself. When memory block sets overlap, there will
+         * be more than one tuple.
+         *<br/>
+         * The <tt>Uint8Array</tt>s in the output are
+         * {@link https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/subarray|subarrays}
+         * of the input data; new memory is <strong>not</strong> allocated for them.
+         *<br/>
+         * The insertion order of keys in the output <tt>Map</tt> is guaranteed to be strictly
+         * ascending. In other words, when iterating through the <tt>Map</tt>, the addresses
+         * will be ordered in ascending order.
+         *<br/>
+         * When two blocks overlap, the corresponding array of tuples will have the tuples ordered
+         * in the insertion order of the input <tt>Map</tt> of block sets.
+         *<br/>
+         *
+         * @param {Map.MemoryMap} memoryMaps The input memory block sets
+         *
+         * @example
+         * import MemoryMap from 'nrf-intel-hex';
+         *
+         * let memMap1 = MemoryMap.fromHex( hexdata1 );
+         * let memMap2 = MemoryMap.fromHex( hexdata2 );
+         * let memMap3 = MemoryMap.fromHex( hexdata3 );
+         *
+         * let maps = new Map([
+         *  ['file A', blocks1],
+         *  ['file B', blocks2],
+         *  ['file C', blocks3]
+         * ]);
+         *
+         * let overlappings = MemoryMap.overlapMemoryMaps(maps);
+         *
+         * for (let [address, tuples] of overlappings) {
+         *     // if 'tuples' has length > 1, there is an overlap starting at 'address'
+         *
+         *     for (let [address, tuples] of overlappings) {
+         *         let [id, bytes] = tuple;
+         *         // 'id' in this example is either 'file A', 'file B' or 'file C'
+         *     }
+         * }
+         * @return {Map.Array<mixed,Uint8Array>} The map of possibly overlapping memory blocks
+         */
+
+    }, {
+        key: 'paginate',
+
+
+        /**
+         * Returns a new instance of {@linkcode MemoryMap}, where:
+         *
+         * <ul>
+         *  <li>Each key (the start address of each <tt>Uint8Array</tt>) is a multiple of
+         *    <tt>pageSize</tt></li>
+         *  <li>The size of each <tt>Uint8Array</tt> is exactly <tt>pageSize</tt></li>
+         *  <li>Bytes from the input map to bytes in the output</li>
+         *  <li>Bytes not in the input are replaced by a padding value</li>
+         * </ul>
+         *<br/>
+         * The scenario is wanting to prepare pages of bytes for a write operation, where the write
+         * operation affects a whole page/sector at once.
+         *<br/>
+         * The insertion order of keys in the output {@linkcode MemoryMap} is guaranteed
+         * to be strictly ascending. In other words, when iterating through the
+         * {@linkcode MemoryMap}, the addresses will be ordered in ascending order.
+         *<br/>
+         * The <tt>Uint8Array</tt>s in the output will be newly allocated.
+         *<br/>
+         *
+         * @param {Number} [pageSize=1024] The size of the output pages, in bytes
+         * @param {Number} [pad=0xFF] The byte value to use for padding
+         * @return {MemoryMap}
+         */
+        value: function paginate() {
+            var pageSize = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 1024;
+            var pad = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0xFF;
+
+            if (pageSize <= 0) {
+                throw new Error('Page size must be greater than zero');
+            }
+            var outPages = new MemoryMap();
+            var page = void 0;
+
+            var sortedKeys = Array.from(this.keys()).sort(function (a, b) {
+                return a - b;
+            });
+
+            for (var i = 0, l = sortedKeys.length; i < l; i++) {
+                var blockAddr = sortedKeys[i];
+                var block = this.get(blockAddr);
+                var blockLength = block.length;
+                var blockEnd = blockAddr + blockLength;
+
+                for (var pageAddr = blockAddr - blockAddr % pageSize; pageAddr < blockEnd; pageAddr += pageSize) {
+                    page = outPages.get(pageAddr);
+                    if (!page) {
+                        page = new Uint8Array(pageSize);
+                        page.fill(pad);
+                        outPages.set(pageAddr, page);
+                    }
+
+                    var offset = pageAddr - blockAddr;
+                    var subBlock = void 0;
+                    if (offset <= 0) {
+                        // First page which intersects the block
+                        subBlock = block.subarray(0, Math.min(pageSize + offset, blockLength));
+                        page.set(subBlock, -offset);
+                    } else {
+                        // Any other page which intersects the block
+                        subBlock = block.subarray(offset, offset + Math.min(pageSize, blockLength - offset));
+                        page.set(subBlock, 0);
+                    }
+                }
+            }
+
+            return outPages;
+        }
+
+        /**
+         * Locates the <tt>Uint8Array</tt> which contains the given offset,
+         * and returns the four bytes held at that offset, as a 32-bit unsigned integer.
+         *
+         *<br/>
+         * Behaviour is similar to {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32|DataView.prototype.getUint32},
+         * except that this operates over a {@linkcode MemoryMap} instead of
+         * over an <tt>ArrayBuffer</tt>, and that this may return <tt>undefined</tt> if
+         * the address is not <em>entirely</em> contained within one of the <tt>Uint8Array</tt>s.
+         *<br/>
+         *
+         * @param {Number} offset The memory offset to read the data
+         * @param {Boolean} [littleEndian=false] Whether to fetch the 4 bytes as a little- or big-endian integer
+         * @return {Number|undefined} An unsigned 32-bit integer number
+         */
+
+    }, {
+        key: 'getUint32',
+        value: function getUint32(offset, littleEndian) {
+            var keys = Array.from(this.keys());
+
+            for (var i = 0, l = keys.length; i < l; i++) {
+                var blockAddr = keys[i];
+                var block = this.get(blockAddr);
+                var blockLength = block.length;
+                var blockEnd = blockAddr + blockLength;
+
+                if (blockAddr <= offset && offset + 4 <= blockEnd) {
+                    return new DataView(block.buffer, offset - blockAddr, 4).getUint32(0, littleEndian);
+                }
+            }
+            return;
+        }
+
+        /**
+         * Returns a <tt>String</tt> of text representing a .hex file.
+         * <br/>
+         * The writer has an opinionated behaviour. Check the project's
+         * {@link https://github.com/NordicSemiconductor/nrf-intel-hex#Features|README file} for details.
+         *
+         * @param {Number} [lineSize=16] Maximum number of bytes to be encoded in each data record.
+         * Must have a value between 1 and 255, as per the specification.
+         *
+         * @return {String} String of text with the .hex representation of the input binary data
+         *
+         * @example
+         * import MemoryMap from 'nrf-intel-hex';
+         *
+         * let memMap = new MemoryMap();
+         * let bytes = new Uint8Array(....);
+         * memMap.set(0x0FF80000, bytes); // The block with 'bytes' will start at offset 0x0FF80000
+         *
+         * let string = memMap.asHexString();
+         */
+
+    }, {
+        key: 'asHexString',
+        value: function asHexString() {
+            var lineSize = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 16;
+
+            var lowAddress = 0; // 16 least significant bits of the current addr
+            var highAddress = -1 << 16; // 16 most significant bits of the current addr
+            var records = [];
+            if (lineSize <= 0) {
+                throw new Error('Size of record must be greater than zero');
+            } else if (lineSize > 255) {
+                throw new Error('Size of record must be less than 256');
+            }
+
+            // Placeholders
+            var offsetRecord = new Uint8Array(6);
+            var recordHeader = new Uint8Array(4);
+
+            var sortedKeys = Array.from(this.keys()).sort(function (a, b) {
+                return a - b;
+            });
+            for (var i = 0, l = sortedKeys.length; i < l; i++) {
+                var blockAddr = sortedKeys[i];
+                var block = this.get(blockAddr);
+
+                // Sanity checks
+                if (!(block instanceof Uint8Array)) {
+                    throw new Error('Block at offset ' + blockAddr + ' is not an Uint8Array');
+                }
+                if (blockAddr < 0) {
+                    throw new Error('Block at offset ' + blockAddr + ' has a negative thus invalid address');
+                }
+                var blockSize = block.length;
+                if (!blockSize) {
+                    continue;
+                } // Skip zero-length blocks
+
+
+                if (blockAddr > highAddress + 0xFFFF) {
+                    // Insert a new 0x04 record to jump to a new 64KiB block
+
+                    // Round up the least significant 16 bits - no bitmasks because they trigger
+                    // base-2 negative numbers, whereas subtracting the modulo maintains precision
+                    highAddress = blockAddr - blockAddr % 0x10000;
+                    lowAddress = 0;
+
+                    offsetRecord[0] = 2; // Length
+                    offsetRecord[1] = 0; // Load offset, high byte
+                    offsetRecord[2] = 0; // Load offset, low byte
+                    offsetRecord[3] = 4; // Record type
+                    offsetRecord[4] = highAddress >> 24; // new address offset, high byte
+                    offsetRecord[5] = highAddress >> 16; // new address offset, low byte
+
+                    records.push(':' + Array.prototype.map.call(offsetRecord, hexpad).join('') + hexpad(checksum(offsetRecord)));
+                }
+
+                if (blockAddr < highAddress + lowAddress) {
+                    throw new Error('Block starting at 0x' + blockAddr.toString(16) + ' overlaps with a previous block.');
+                }
+
+                lowAddress = blockAddr % 0x10000;
+                var blockOffset = 0;
+                var blockEnd = blockAddr + blockSize;
+                if (blockEnd > 0xFFFFFFFF) {
+                    throw new Error('Data cannot be over 0xFFFFFFFF');
+                }
+
+                // Loop for every 64KiB memory segment that spans this block
+                while (highAddress + lowAddress < blockEnd) {
+
+                    if (lowAddress > 0xFFFF) {
+                        // Insert a new 0x04 record to jump to a new 64KiB block
+                        highAddress += 1 << 16; // Increase by one
+                        lowAddress = 0;
+
+                        offsetRecord[0] = 2; // Length
+                        offsetRecord[1] = 0; // Load offset, high byte
+                        offsetRecord[2] = 0; // Load offset, low byte
+                        offsetRecord[3] = 4; // Record type
+                        offsetRecord[4] = highAddress >> 24; // new address offset, high byte
+                        offsetRecord[5] = highAddress >> 16; // new address offset, low byte
+
+                        records.push(':' + Array.prototype.map.call(offsetRecord, hexpad).join('') + hexpad(checksum(offsetRecord)));
+                    }
+
+                    var recordSize = -1;
+                    // Loop for every record for that spans the current 64KiB memory segment
+                    while (lowAddress < 0x10000 && recordSize) {
+                        recordSize = Math.min(lineSize, // Normal case
+                        blockEnd - highAddress - lowAddress, // End of block
+                        0x10000 - lowAddress // End of low addresses
+                        );
+
+                        if (recordSize) {
+
+                            recordHeader[0] = recordSize; // Length
+                            recordHeader[1] = lowAddress >> 8; // Load offset, high byte
+                            recordHeader[2] = lowAddress; // Load offset, low byte
+                            recordHeader[3] = 0; // Record type
+
+                            var subBlock = block.subarray(blockOffset, blockOffset + recordSize); // Data bytes for this record
+
+                            records.push(':' + Array.prototype.map.call(recordHeader, hexpad).join('') + Array.prototype.map.call(subBlock, hexpad).join('') + hexpad(checksumTwo(recordHeader, subBlock)));
+
+                            blockOffset += recordSize;
+                            lowAddress += recordSize;
+                        }
+                    }
+                }
+            }
+
+            records.push(':00000001FF'); // EOF record
+
+            return records.join('\n');
+        }
+
+        /**
+         * Performs a deep copy of the current {@linkcode MemoryMap}, returning a new one
+         * with exactly the same contents, but allocating new memory for each of its
+         * <tt>Uint8Array</tt>s.
+         *
+         * @return {MemoryMap}
+         */
+
+    }, {
+        key: 'clone',
+        value: function clone() {
+            var cloned = new MemoryMap();
+
+            var _iteratorNormalCompletion3 = true;
+            var _didIteratorError3 = false;
+            var _iteratorError3 = undefined;
+
+            try {
+                for (var _iterator3 = this[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                    var _step3$value = _slicedToArray(_step3.value, 2),
+                        addr = _step3$value[0],
+                        value = _step3$value[1];
+
+                    cloned.set(addr, new Uint8Array(value));
+                }
+            } catch (err) {
+                _didIteratorError3 = true;
+                _iteratorError3 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                        _iterator3.return();
+                    }
+                } finally {
+                    if (_didIteratorError3) {
+                        throw _iteratorError3;
+                    }
+                }
+            }
+
+            return cloned;
+        }
+
+        /**
+         * Given one <tt>Uint8Array</tt>, looks through its contents and returns a new
+         * {@linkcode MemoryMap}, stripping away those regions where there are only
+         * padding bytes.
+         * <br/>
+         * The start of the input <tt>Uint8Array</tt> is assumed to be offset zero for the output.
+         * <br/>
+         * The use case here is dumping memory from a working device and try to see the
+         * "interesting" memory regions it has. This assumes that there is a constant,
+         * predefined padding byte value being used in the "non-interesting" regions.
+         * In other words: this will work as long as the dump comes from a flash memory
+         * which has been previously erased (thus <tt>0xFF</tt>s for padding), or from a
+         * previously blanked HDD (thus <tt>0x00</tt>s for padding).
+         * <br/>
+         * This method uses <tt>subarray</tt> on the input data, and thus does not allocate memory
+         * for the <tt>Uint8Array</tt>s.
+         *
+         * @param {Uint8Array} bytes The input data
+         * @param {Number} [padByte=0xFF] The value of the byte assumed to be used as padding
+         * @param {Number} [minPadLength=64] The minimum number of consecutive pad bytes to
+         * be considered actual padding
+         *
+         * @return {MemoryMap}
+         */
+
+    }, {
+        key: 'slice',
+
+
+        /**
+         * Returns a new instance of {@linkcode MemoryMap}, containing only data between
+         * the addresses <tt>address</tt> and <tt>address + length</tt>.
+         * Behaviour is similar to {@linkcode https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array/slice|Array.prototype.slice},
+         * in that the return value is a portion of the current {@linkcode MemoryMap}.
+         *
+         * <br/>
+         * The returned {@linkcode MemoryMap} might be empty.
+         *
+         * <br/>
+         * Internally, this uses <tt>subarray</tt>, so new memory is not allocated.
+         *
+         * @param {Number} address The start address of the slice
+         * @param {Number} length The length of memory map to slice out
+         * @return {MemoryMap}
+         */
+        value: function slice(address) {
+            var length = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : Infinity;
+
+            if (length < 0) {
+                throw new Error('Length of the slice cannot be negative');
+            }
+
+            var sliced = new MemoryMap();
+
+            var _iteratorNormalCompletion4 = true;
+            var _didIteratorError4 = false;
+            var _iteratorError4 = undefined;
+
+            try {
+                for (var _iterator4 = this[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                    var _step4$value = _slicedToArray(_step4.value, 2),
+                        blockAddr = _step4$value[0],
+                        block = _step4$value[1];
+
+                    var blockLength = block.length;
+
+                    if (blockAddr + blockLength >= address && blockAddr < address + length) {
+                        var sliceStart = Math.max(address, blockAddr);
+                        var sliceEnd = Math.min(address + length, blockAddr + blockLength);
+                        var sliceLength = sliceEnd - sliceStart;
+                        var relativeSliceStart = sliceStart - blockAddr;
+
+                        if (sliceLength > 0) {
+                            sliced.set(sliceStart, block.subarray(relativeSliceStart, relativeSliceStart + sliceLength));
+                        }
+                    }
+                }
+            } catch (err) {
+                _didIteratorError4 = true;
+                _iteratorError4 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion4 && _iterator4.return) {
+                        _iterator4.return();
+                    }
+                } finally {
+                    if (_didIteratorError4) {
+                        throw _iteratorError4;
+                    }
+                }
+            }
+
+            return sliced;
+        }
+
+        /**
+         * Returns a new instance of {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/getUint32|Uint8Array}, containing only data between
+         * the addresses <tt>address</tt> and <tt>address + length</tt>. Any byte without a value
+         * in the input {@linkcode MemoryMap} will have a value of <tt>padByte</tt>.
+         *
+         * <br/>
+         * This method allocates new memory.
+         *
+         * @param {Number} address The start address of the slice
+         * @param {Number} length The length of memory map to slice out
+         * @param {Number} [padByte=0xFF] The value of the byte assumed to be used as padding
+         * @return {MemoryMap}
+         */
+
+    }, {
+        key: 'slicePad',
+        value: function slicePad(address, length) {
+            var padByte = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 0xFF;
+
+            if (length < 0) {
+                throw new Error('Length of the slice cannot be negative');
+            }
+
+            var out = new Uint8Array(length).fill(padByte);
+
+            var _iteratorNormalCompletion5 = true;
+            var _didIteratorError5 = false;
+            var _iteratorError5 = undefined;
+
+            try {
+                for (var _iterator5 = this[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                    var _step5$value = _slicedToArray(_step5.value, 2),
+                        blockAddr = _step5$value[0],
+                        block = _step5$value[1];
+
+                    var blockLength = block.length;
+
+                    if (blockAddr + blockLength >= address && blockAddr < address + length) {
+                        var sliceStart = Math.max(address, blockAddr);
+                        var sliceEnd = Math.min(address + length, blockAddr + blockLength);
+                        var sliceLength = sliceEnd - sliceStart;
+                        var relativeSliceStart = sliceStart - blockAddr;
+
+                        if (sliceLength > 0) {
+                            out.set(block.subarray(relativeSliceStart, relativeSliceStart + sliceLength), sliceStart - address);
+                        }
+                    }
+                }
+            } catch (err) {
+                _didIteratorError5 = true;
+                _iteratorError5 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion5 && _iterator5.return) {
+                        _iterator5.return();
+                    }
+                } finally {
+                    if (_didIteratorError5) {
+                        throw _iteratorError5;
+                    }
+                }
+            }
+
+            return out;
+        }
+
+        /**
+         * Checks whether the current memory map contains the one given as a parameter.
+         *
+         * <br/>
+         * "Contains" means that all the offsets that have a byte value in the given
+         * memory map have a value in the current memory map, and that the byte values
+         * are the same.
+         *
+         * <br/>
+         * An empty memory map is always contained in any other memory map.
+         *
+         * <br/>
+         * Returns boolean <tt>true</tt> if the memory map is contained, <tt>false</tt>
+         * otherwise.
+         *
+         * @param {MemoryMap} memMap The memory map to check
+         * @return {Boolean}
+         */
+
+    }, {
+        key: 'contains',
+        value: function contains(memMap) {
+            var _iteratorNormalCompletion6 = true;
+            var _didIteratorError6 = false;
+            var _iteratorError6 = undefined;
+
+            try {
+                for (var _iterator6 = memMap[Symbol.iterator](), _step6; !(_iteratorNormalCompletion6 = (_step6 = _iterator6.next()).done); _iteratorNormalCompletion6 = true) {
+                    var _step6$value = _slicedToArray(_step6.value, 2),
+                        blockAddr = _step6$value[0],
+                        block = _step6$value[1];
+
+                    var blockLength = block.length;
+
+                    var slice = this.slice(blockAddr, blockLength).join().get(blockAddr);
+
+                    if (!slice || slice.length !== blockLength) {
+                        return false;
+                    }
+
+                    for (var i in block) {
+                        if (block[i] !== slice[i]) {
+                            return false;
+                        }
+                    }
+                }
+            } catch (err) {
+                _didIteratorError6 = true;
+                _iteratorError6 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion6 && _iterator6.return) {
+                        _iterator6.return();
+                    }
+                } finally {
+                    if (_didIteratorError6) {
+                        throw _iteratorError6;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }, {
+        key: 'size',
+        get: function get() {
+            return this._blocks.size;
+        }
+    }], [{
+        key: 'fromHex',
+        value: function fromHex(hexText) {
+            var maxBlockSize = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : Infinity;
+
+            var blocks = new MemoryMap();
+
+            var lastCharacterParsed = 0;
+            var matchResult = void 0;
+            var recordCount = 0;
+
+            // Upper Linear Base Address, the 16 most significant bits (2 bytes) of
+            // the current 32-bit (4-byte) address
+            // In practice this is a offset that is summed to the "load offset" of the
+            // data records
+            var ulba = 0;
+
+            hexLineRegexp.lastIndex = 0; // Reset the regexp, if not it would skip content when called twice
+
+            while ((matchResult = hexLineRegexp.exec(hexText)) !== null) {
+                recordCount++;
+
+                // By default, a regexp loop ignores gaps between matches, but
+                // we want to be aware of them.
+                if (lastCharacterParsed !== matchResult.index) {
+                    throw new Error('Malformed hex file: Could not parse between characters ' + lastCharacterParsed + ' and ' + matchResult.index + ' ("' + hexText.substring(lastCharacterParsed, Math.min(matchResult.index, lastCharacterParsed + 16)).trim() + '")');
+                }
+                lastCharacterParsed = hexLineRegexp.lastIndex;
+
+                // Give pretty names to the match's capture groups
+
+                var _matchResult = matchResult,
+                    _matchResult2 = _slicedToArray(_matchResult, 3),
+                    recordStr = _matchResult2[1],
+                    recordChecksum = _matchResult2[2];
+
+                // String to Uint8Array - https://stackoverflow.com/questions/43131242/how-to-convert-a-hexademical-string-of-data-to-an-arraybuffer-in-javascript
+
+
+                var recordBytes = new Uint8Array(recordStr.match(/[\da-f]{2}/gi).map(function (h) {
+                    return parseInt(h, 16);
+                }));
+
+                var recordLength = recordBytes[0];
+                if (recordLength + 4 !== recordBytes.length) {
+                    throw new Error('Mismatched record length at record ' + recordCount + ' (' + matchResult[0].trim() + '), expected ' + recordLength + ' data bytes but actual length is ' + (recordBytes.length - 4));
+                }
+
+                var cs = checksum(recordBytes);
+                if (parseInt(recordChecksum, 16) !== cs) {
+                    throw new Error('Checksum failed at record ' + recordCount + ' (' + matchResult[0].trim() + '), should be ' + cs.toString(16));
+                }
+
+                var offset = (recordBytes[1] << 8) + recordBytes[2];
+                var recordType = recordBytes[3];
+                var data = recordBytes.subarray(4);
+
+                if (recordType === 0) {
+                    // Data record, contains data
+                    // Create a new block, at (upper linear base address + offset)
+                    if (blocks.has(ulba + offset)) {
+                        throw new Error('Duplicated data at record ' + recordCount + ' (' + matchResult[0].trim() + ')');
+                    }
+                    if (offset + data.length > 0x10000) {
+                        throw new Error('Data at record ' + recordCount + ' (' + matchResult[0].trim() + ') wraps over 0xFFFF. This would trigger ambiguous behaviour. Please restructure your data so that for every record the data offset plus the data length do not exceed 0xFFFF.');
+                    }
+
+                    blocks.set(ulba + offset, data);
+                } else {
+
+                    // All non-data records must have a data offset of zero
+                    if (offset !== 0) {
+                        throw new Error('Record ' + recordCount + ' (' + matchResult[0].trim() + ') must have 0000 as data offset.');
+                    }
+
+                    switch (recordType) {
+                        case 1:
+                            // EOF
+                            if (lastCharacterParsed !== hexText.length) {
+                                // This record should be at the very end of the string
+                                throw new Error('There is data after an EOF record at record ' + recordCount);
+                            }
+
+                            return blocks.join(maxBlockSize);
+
+                        case 2:
+                            // Extended Segment Address Record
+                            // Sets the 16 most significant bits of the 20-bit Segment Base
+                            // Address for the subsequent data.
+                            ulba = (data[0] << 8) + data[1] << 4;
+                            break;
+
+                        case 3:
+                            // Start Segment Address Record
+                            // Do nothing. Record type 3 only applies to 16-bit Intel CPUs,
+                            // where it should reset the program counter (CS+IP CPU registers)
+                            break;
+
+                        case 4:
+                            // Extended Linear Address Record
+                            // Sets the 16 most significant (upper) bits of the 32-bit Linear Address
+                            // for the subsequent data
+                            ulba = (data[0] << 8) + data[1] << 16;
+                            break;
+
+                        case 5:
+                            // Start Linear Address Record
+                            // Do nothing. Record type 5 only applies to 32-bit Intel CPUs,
+                            // where it should reset the program counter (EIP CPU register)
+                            // It might have meaning for other CPU architectures
+                            // (see http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka9903.html )
+                            // but will be ignored nonetheless.
+                            break;
+                        default:
+                            throw new Error('Invalid record type 0x' + hexpad(recordType) + ' at record ' + recordCount + ' (should be between 0x00 and 0x05)');
+                    }
+                }
+            }
+
+            if (recordCount) {
+                throw new Error('No EOF record at end of file');
+            } else {
+                throw new Error('Malformed .hex file, could not parse any registers');
+            }
+        }
+    }, {
+        key: 'overlapMemoryMaps',
+        value: function overlapMemoryMaps(memoryMaps) {
+            // First pass: create a list of addresses where any block starts or ends.
+            var cuts = new Set();
+            var _iteratorNormalCompletion7 = true;
+            var _didIteratorError7 = false;
+            var _iteratorError7 = undefined;
+
+            try {
+                for (var _iterator7 = memoryMaps[Symbol.iterator](), _step7; !(_iteratorNormalCompletion7 = (_step7 = _iterator7.next()).done); _iteratorNormalCompletion7 = true) {
+                    var _step7$value = _slicedToArray(_step7.value, 2),
+                        blocks = _step7$value[1];
+
+                    var _iteratorNormalCompletion8 = true;
+                    var _didIteratorError8 = false;
+                    var _iteratorError8 = undefined;
+
+                    try {
+                        for (var _iterator8 = blocks[Symbol.iterator](), _step8; !(_iteratorNormalCompletion8 = (_step8 = _iterator8.next()).done); _iteratorNormalCompletion8 = true) {
+                            var _step8$value = _slicedToArray(_step8.value, 2),
+                                address = _step8$value[0],
+                                block = _step8$value[1];
+
+                            cuts.add(address);
+                            cuts.add(address + block.length);
+                        }
+                    } catch (err) {
+                        _didIteratorError8 = true;
+                        _iteratorError8 = err;
+                    } finally {
+                        try {
+                            if (!_iteratorNormalCompletion8 && _iterator8.return) {
+                                _iterator8.return();
+                            }
+                        } finally {
+                            if (_didIteratorError8) {
+                                throw _iteratorError8;
+                            }
+                        }
+                    }
+                }
+            } catch (err) {
+                _didIteratorError7 = true;
+                _iteratorError7 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion7 && _iterator7.return) {
+                        _iterator7.return();
+                    }
+                } finally {
+                    if (_didIteratorError7) {
+                        throw _iteratorError7;
+                    }
+                }
+            }
+
+            var orderedCuts = Array.from(cuts.values()).sort(function (a, b) {
+                return a - b;
+            });
+            var overlaps = new Map();
+
+            // Second pass: iterate through the cuts, get slices of every intersecting blockset
+
+            var _loop = function _loop(i, l) {
+                var cut = orderedCuts[i];
+                var nextCut = orderedCuts[i + 1];
+                var tuples = [];
+
+                var _iteratorNormalCompletion9 = true;
+                var _didIteratorError9 = false;
+                var _iteratorError9 = undefined;
+
+                try {
+                    for (var _iterator9 = memoryMaps[Symbol.iterator](), _step9; !(_iteratorNormalCompletion9 = (_step9 = _iterator9.next()).done); _iteratorNormalCompletion9 = true) {
+                        var _step9$value = _slicedToArray(_step9.value, 2),
+                            setId = _step9$value[0],
+                            blocks = _step9$value[1];
+
+                        // Find the block with the highest address that is equal or lower to
+                        // the current cut (if any)
+                        var blockAddr = Array.from(blocks.keys()).reduce(function (acc, val) {
+                            if (val > cut) {
+                                return acc;
+                            }
+                            return Math.max(acc, val);
+                        }, -1);
+
+                        if (blockAddr !== -1) {
+                            var block = blocks.get(blockAddr);
+                            var subBlockStart = cut - blockAddr;
+                            var subBlockEnd = nextCut - blockAddr;
+
+                            if (subBlockStart < block.length) {
+                                tuples.push([setId, block.subarray(subBlockStart, subBlockEnd)]);
+                            }
+                        }
+                    }
+                } catch (err) {
+                    _didIteratorError9 = true;
+                    _iteratorError9 = err;
+                } finally {
+                    try {
+                        if (!_iteratorNormalCompletion9 && _iterator9.return) {
+                            _iterator9.return();
+                        }
+                    } finally {
+                        if (_didIteratorError9) {
+                            throw _iteratorError9;
+                        }
+                    }
+                }
+
+                if (tuples.length) {
+                    overlaps.set(cut, tuples);
+                }
+            };
+
+            for (var i = 0, l = orderedCuts.length - 1; i < l; i++) {
+                _loop(i, l);
+            }
+
+            return overlaps;
+        }
+
+        /**
+         * Given the output of the {@linkcode MemoryMap.overlapMemoryMaps|overlapMemoryMaps}
+         * (a <tt>Map</tt> of address to an <tt>Array</tt> of <tt>(id, Uint8Array)</tt> tuples),
+         * returns a {@linkcode MemoryMap}. This discards the IDs in the process.
+         *<br/>
+         * The output <tt>Map</tt> contains as many entries as the input one (using the same addresses
+         * as keys), but the value for each entry will be the <tt>Uint8Array</tt> of the <b>last</b>
+         * tuple for each address in the input data.
+         *<br/>
+         * The scenario is wanting to join together several parsed .hex files, not worrying about
+         * their overlaps.
+         *<br/>
+         *
+         * @param {Map.Array<mixed,Uint8Array>} overlaps The (possibly overlapping) input memory blocks
+         * @return {MemoryMap} The flattened memory blocks
+         */
+
+    }, {
+        key: 'flattenOverlaps',
+        value: function flattenOverlaps(overlaps) {
+            return new MemoryMap(Array.from(overlaps.entries()).map(function (_ref) {
+                var _ref2 = _slicedToArray(_ref, 2),
+                    address = _ref2[0],
+                    tuples = _ref2[1];
+
+                return [address, tuples[tuples.length - 1][1]];
+            }));
+        }
+    }, {
+        key: 'fromPaddedUint8Array',
+        value: function fromPaddedUint8Array(bytes) {
+            var padByte = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 0xFF;
+            var minPadLength = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : 64;
+
+
+            if (!(bytes instanceof Uint8Array)) {
+                throw new Error('Bytes passed to fromPaddedUint8Array are not an Uint8Array');
+            }
+
+            // The algorithm used is naïve and checks every byte.
+            // An obvious optimization would be to implement Boyer-Moore
+            // (see https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_string_search_algorithm )
+            // or otherwise start skipping up to minPadLength bytes when going through a non-pad
+            // byte.
+            // Anyway, we could expect a lot of cases where there is a majority of pad bytes,
+            // and the algorithm should check most of them anyway, so the perf gain is questionable.
+
+            var memMap = new MemoryMap();
+            var consecutivePads = 0;
+            var lastNonPad = -1;
+            var firstNonPad = 0;
+            var skippingBytes = false;
+            var l = bytes.length;
+
+            for (var addr = 0; addr < l; addr++) {
+                var byte = bytes[addr];
+
+                if (byte === padByte) {
+                    consecutivePads++;
+                    if (consecutivePads >= minPadLength) {
+                        // Edge case: ignore writing a zero-length block when skipping
+                        // bytes at the beginning of the input
+                        if (lastNonPad !== -1) {
+                            /// Add the previous block to the result memMap
+                            memMap.set(firstNonPad, bytes.subarray(firstNonPad, lastNonPad + 1));
+                        }
+
+                        skippingBytes = true;
+                    }
+                } else {
+                    if (skippingBytes) {
+                        skippingBytes = false;
+                        firstNonPad = addr;
+                    }
+                    lastNonPad = addr;
+                    consecutivePads = 0;
+                }
+            }
+
+            // At EOF, add the last block if not skipping bytes already (and input not empty)
+            if (!skippingBytes && lastNonPad !== -1) {
+                memMap.set(firstNonPad, bytes.subarray(firstNonPad, l));
+            }
+
+            return memMap;
+        }
+    }]);
+
+    return MemoryMap;
+}();
+
+return MemoryMap;
+
+})));
+//# sourceMappingURL=intel-hex.browser.js.map


### PR DESCRIPTION
Add partial flashing to the Python Editor using a similar method as is used in pxt-microbit.

- Checksums the existing pages in flash on the micro:bit.
- Compares the checksums to those of the image to be flashed.
- Writes the pages with a different checksum to micro:bit RAM to be copied across.

- Falls back to full flashing on error or if too many pages differ.