### PR TITLE
Append error to any existing errors

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1248,16 +1248,16 @@ function web_editor(config) {
             } 
         }
 
-        var errorHTML = '<div>' + ((err.message === undefined) ? "WebUSB Error" : err.message) + '<br >' + 
-                    errorDescription + '<div class="flashing-overlay-buttons">' +
-                    (err.name === 'device-disconnected'
+        var errorHTML = '<div><strong>' + ((err.message === undefined) ? "WebUSB Error" : err.message) + '</strong><br >' + 
+                    errorDescription + '</div>' + '<div class="flashing-overlay-buttons"><hr />' +
+                    ((err.name === 'device-disconnected' && $("#flashing-overlay-error").html() === "")
                             ?  ""
                             : '<a href="#" id="flashing-overlay-download">' +
                               config["translate"]["webusb"]["download"] + 
                               '</a> | ') +
                     '<a href="#" onclick="flashErrorClose()">' +
                     config["translate"]["webusb"]["close"] +
-                    '</a></div></div>';
+                    '</a></div>';
 
         // Show error message
         if($("#flashing-overlay-error").html() == "") {

--- a/python-main.js
+++ b/python-main.js
@@ -1249,20 +1249,21 @@ function web_editor(config) {
         }
 
         var errorHTML = '<div>' + ((err.message === undefined) ? "WebUSB Error" : err.message) + '<br >' + 
-                    errorDescription +
+                    errorDescription + '<div class="flashing-overlay-buttons">' +
                     (err.name === 'device-disconnected'
                             ?  ""
-                            : '<br ><a href="#" id="flashing-overlay-download">' +
+                            : '<a href="#" id="flashing-overlay-download">' +
                               config["translate"]["webusb"]["download"] + 
                               '</a> | ') +
                     '<a href="#" onclick="flashErrorClose()">' +
                     config["translate"]["webusb"]["close"] +
-                    '</a></div>';
+                    '</a></div></div>';
 
         // Show error message
         if($("#flashing-overlay-error").html() == "") {
             $("#flashing-overlay-error").html(errorHTML);
         } else {
+            $(".flashing-overlay-buttons").hide(); // Hide previous buttons
             $("#flashing-overlay-error").append("<hr />" + errorHTML);
         }
 

--- a/python-main.js
+++ b/python-main.js
@@ -1248,23 +1248,23 @@ function web_editor(config) {
             } 
         }
 
-        // Show error message
-        $("#flashing-overlay-error").html(
-            '<div>' +
-                '<strong>' + ((err.message === undefined) ? "WebUSB Error" : err.message) + '</strong><br>' + 
-                errorDescription +
-                '<div class="modal-msg-links">' +
+        var errorHTML = '<div>' + ((err.message === undefined) ? "WebUSB Error" : err.message) + '<br >' + 
+                    errorDescription +
                     (err.name === 'device-disconnected'
                             ?  ""
                             : '<br ><a href="#" id="flashing-overlay-download">' +
-                            config["translate"]["webusb"]["download"] +
-                            '</a> | ') +
+                              config["translate"]["webusb"]["download"] + 
+                              '</a> | ') +
                     '<a href="#" onclick="flashErrorClose()">' +
                     config["translate"]["webusb"]["close"] +
-                    '</a>' +
-                '</div>' +
-            '</div>'
-        );
+                    '</a></div>';
+
+        // Show error message
+        if($("#flashing-overlay-error").html() == "") {
+            $("#flashing-overlay-error").html(errorHTML);
+        } else {
+            $("#flashing-overlay-error").append("<hr />" + errorHTML);
+        }
 
         // Attach download handler
         $("#flashing-overlay-download").click(doDownload);
@@ -1393,17 +1393,16 @@ function web_editor(config) {
             var timeTaken = (new Date().getTime() - startTime);
             var details = {"flash-type": (usePartialFlashing ? "partial-flash" : "full-flash"), "event-type": "flash-time", "message": timeTaken};
             document.dispatchEvent(new CustomEvent('webusb', { detail: details }));
-        })
-        .catch(webusbErrorHandler)
-        .finally(function() {
-            // Remove event listener
-            window.removeEventListener("unhandledrejection", webusbErrorHandler);
             
             // Close overview
             setTimeout(function(){
                 $("#flashing-overlay-container").hide();
             }, 500);
-
+        })
+        .catch(webusbErrorHandler)
+        .finally(function() {
+            // Remove event listener
+            window.removeEventListener("unhandledrejection", webusbErrorHandler);
         });
     }
 

--- a/python-main.js
+++ b/python-main.js
@@ -1275,6 +1275,10 @@ function web_editor(config) {
     }
 
     function doDisconnect() {
+
+        // Remove disconnect listenr
+        navigator.usb.removeEventListener('disconnect', showDisconnectError);
+
         // Hide serial and disconnect if open
         if ($("#repl").css('display') != 'none') {
             $("#repl").hide();


### PR DESCRIPTION
Fixes https://github.com/microbit-foundation/platform-software-issue-tracker/issues/435
Additional errors are appended to original

Fixes https://github.com/microbit-foundation/platform-software-issue-tracker/issues/449
> The error modal closes itself
I've moved the timeout for auto close from the `finally` block. Auto closed is used to close the 'tick' after 500ms

> After the error modal is shown the device is disconnected (the Editor changes the connect and flash buttons back), but if the device is physically unplugged at that point we still get the device disconnected error
