### PR TITLE
Webusb ie10 fix final

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1401,7 +1401,9 @@ function web_editor(config) {
 
     function modalMsg(title, content, links){
         var overlayContainer = "#modal-msg-overlay-container";
-        $(overlayContainer).css("display", "flex");
+        //$(overlayContainer).css({"display": "-webkit-box", "display": "-ms-flexbox", "display": "-webkit-flex", "display": "flex"});
+        $(overlayContainer).css("display","block");
+        //$("#modal-overlay-container").css({"width":"100%","height":"100%"});
         $("#modal-msg-title").text(title);
         $("#modal-msg-content").html(content); 
         if (links) {

--- a/python-main.js
+++ b/python-main.js
@@ -1401,9 +1401,7 @@ function web_editor(config) {
 
     function modalMsg(title, content, links){
         var overlayContainer = "#modal-msg-overlay-container";
-        //$(overlayContainer).css({"display": "-webkit-box", "display": "-ms-flexbox", "display": "-webkit-flex", "display": "flex"});
         $(overlayContainer).css("display","block");
-        //$("#modal-overlay-container").css({"width":"100%","height":"100%"});
         $("#modal-msg-title").text(title);
         $("#modal-msg-content").html(content); 
         if (links) {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -664,16 +664,13 @@ input:checked + .menu-switch-slider:before {
 /* WebUSB */
 .modal-overlay-container {
     position: absolute;
-    opacity: 0.99;
-    z-index: 200;
+    z-index: 99;
     background-color: rgba(255,255,255,0.6);
     margin: auto auto;
-    width: 100%;
     top: 0px;
+    width: 100%;
     height: 100%;
     z-index: 99;
-    justify-content: center;
-    align-items: center;
     text-align: center;
     display: none;
     line-height: 25px;
@@ -686,7 +683,7 @@ input:checked + .menu-switch-slider:before {
 
 #modal-msg-overlay{
   position: relative;
-  top: 250px;
+  top: 19%;
   width: 70%;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -664,7 +664,6 @@ input:checked + .menu-switch-slider:before {
 /* WebUSB */
 .modal-overlay-container {
     position: absolute;
-    z-index: 99;
     background-color: rgba(255,255,255,0.6);
     margin: auto auto;
     top: 0px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -670,6 +670,8 @@ input:checked + .menu-switch-slider:before {
     width: 100%;
     height: 100%;
     z-index: 99;
+    justify-content: center;
+    align-items: center;
     text-align: center;
     display: none;
     line-height: 25px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -664,9 +664,12 @@ input:checked + .menu-switch-slider:before {
 /* WebUSB */
 .modal-overlay-container {
     position: absolute;
+    opacity: 0.99;
+    z-index: 200;
     background-color: rgba(255,255,255,0.6);
     margin: auto auto;
     width: 100%;
+    top: 0px;
     height: 100%;
     z-index: 99;
     justify-content: center;
@@ -679,7 +682,12 @@ input:checked + .menu-switch-slider:before {
 
 .modal-msg-overlay-container {
   text-align: left;
+}
 
+#modal-msg-overlay{
+  position: relative;
+  top: 250px;
+  width: 70%;
 }
 
 .modal-overlay {


### PR DESCRIPTION
'WebUSB not supported' message was not shown in Internet Explorer 10. I fixed this by explicitly stating its location on the screen and making its position relative. The css attribute 'display: flex' is also not compatible with IE10, so I changed the display to 'block'.
I deleted the justify-content and align-items attributes because they were redundant.

Closes microbit-foundation/platform-software-issue-tracker#442