### PR TITLE
Fix 2nd flash after MakeCode fails

### DIFF
--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -591,7 +591,7 @@ let PartialFlashing = {
 
                 if (aligned.length > 100) {
                     try {
-                        await this.fullFlashAsync(dapwrapper, image);
+                        await this.fullFlashAsync(dapwrapper, image_string);
                     } catch {
                         PartialFlashingUtils.log(`Full flash failed, attempting partial flash.`);
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
@@ -602,7 +602,7 @@ let PartialFlashing = {
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
                     } catch {
                         PartialFlashingUtils.log(`Partial flash failed, attempting full flash.`);
-                        await this.fullFlashAsync(dapwrapper, image);
+                        await this.fullFlashAsync(dapwrapper, image_string);
                     }
                 }
 
@@ -648,7 +648,7 @@ let PartialFlashing = {
 
     // Flash the micro:bit's ROM with the provided image, resetting the micro:bit first.
     // Drawn from https://github.com/microsoft/pxt-microbit/blob/dec5b8ce72d5c2b4b0b20aafefce7474a6f0c7b2/editor/extension.tsx#L439
-    flashAsync: async function(dapwrapper, image, updateProgress) {
+    flashAsync: async function(dapwrapper, image_bytes, image_string, updateProgress) {
         try {
             let p = Promise.resolve()
                 .then(() => {
@@ -673,13 +673,13 @@ let PartialFlashing = {
             let ret = await Promise.race([p, timeout])
             .then(() => {
                 PartialFlashingUtils.log("Begin Flashing");
-                return this.partialFlashAsync(dapwrapper, image, updateProgress);
+                return this.partialFlashAsync(dapwrapper, image_bytes, updateProgress);
             });
             return ret;
         } catch (err) {
             // Fall back to full flash if attempting to reset times out.
             if (err === "Timeout") {
-                return this.fullFlashAsync(dapwrapper, image);
+                return this.fullFlashAsync(dapwrapper, image_string);
             }
             return Promise.reject(err);
         }

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -602,6 +602,10 @@ let PartialFlashing = {
             })
             .catch(error => {
                 PartialFlashingUtils.log(error);
+
+                var details = {"flash-type": "partial-flash", "event-type": "fallback-to-full", "message": 0 };
+                document.dispatchEvent(new CustomEvent('webusb', { detail: details }));
+
                 this.fullFlashAsync(dapwrapper, image);
             });
     },

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -591,7 +591,7 @@ let PartialFlashing = {
 
                 if (aligned.length > 100) {
                     try {
-                        await this.fullFlashAsync(dapwrapper, image);
+                        await this.fullFlashAsync(dapwrapper, image_string);
                     } catch {
                         PartialFlashingUtils.log(`Full flash failed, attempting partial flash.`);
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
@@ -602,7 +602,7 @@ let PartialFlashing = {
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
                     } catch {
                         PartialFlashingUtils.log(`Partial flash failed, attempting full flash.`);
-                        await this.fullFlashAsync(dapwrapper, image);
+                        await this.fullFlashAsync(dapwrapper, image_string);
                     }
                 }
 

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -606,7 +606,7 @@ let PartialFlashing = {
                 var details = {"flash-type": "partial-flash", "event-type": "fallback-to-full", "message": 0 };
                 document.dispatchEvent(new CustomEvent('webusb', { detail: details }));
 
-                this.fullFlashAsync(dapwrapper, image);
+                return this.fullFlashAsync(dapwrapper, image);
             });
     },
 

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -591,7 +591,7 @@ let PartialFlashing = {
 
                 if (aligned.length > 100) {
                     try {
-                        await this.fullFlashAsync(dapwrapper, image_string);
+                        await this.fullFlashAsync(dapwrapper, image);
                     } catch {
                         PartialFlashingUtils.log(`Full flash failed, attempting partial flash.`);
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
@@ -602,7 +602,7 @@ let PartialFlashing = {
                         await this.partialFlashCoreAsync(dapwrapper, aligned, updateProgress);
                     } catch {
                         PartialFlashingUtils.log(`Partial flash failed, attempting full flash.`);
-                        await this.fullFlashAsync(dapwrapper, image_string);
+                        await this.fullFlashAsync(dapwrapper, image);
                     }
                 }
 

--- a/python-main.js
+++ b/python-main.js
@@ -1266,13 +1266,14 @@ function web_editor(config) {
             // Push binary to board
             p = PartialFlashing.connectDapAsync()
                 .then(function() {
-                    var output = generateFullHex("bytes");
+                    var output_bytes = generateFullHex("bytes");
+                    var output_string = generateFullHex("string");
                     var updateProgress = function(progress) {
                         $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
                     }
                     $("#webusb-flashing-loader").hide();
                     $("#webusb-flashing-progress").val(0).css("display", "inline-block");
-                    return PartialFlashing.flashAsync(window.dapwrapper, output, updateProgress);
+                    return PartialFlashing.flashAsync(window.dapwrapper, output_bytes, output_string, updateProgress);
                 })
 
         }

--- a/python-main.js
+++ b/python-main.js
@@ -1267,7 +1267,7 @@ function web_editor(config) {
             p = PartialFlashing.connectDapAsync()
                 .then(function() {
                     var output_bytes = generateFullHex("bytes");
-                    var output_string = generateFullHex("string");
+                    var output_string = generateFullHex("bytes");
                     var updateProgress = function(progress) {
                         $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
                     }

--- a/python-main.js
+++ b/python-main.js
@@ -1266,14 +1266,13 @@ function web_editor(config) {
             // Push binary to board
             p = PartialFlashing.connectDapAsync()
                 .then(function() {
-                    var output_bytes = generateFullHex("bytes");
-                    var output_string = generateFullHex("bytes");
+                    var output = generateFullHex("bytes");
                     var updateProgress = function(progress) {
                         $("#webusb-flashing-progress").val(progress).css("display", "inline-block");
                     }
                     $("#webusb-flashing-loader").hide();
                     $("#webusb-flashing-progress").val(0).css("display", "inline-block");
-                    return PartialFlashing.flashAsync(window.dapwrapper, output_bytes, output_string, updateProgress);
+                    return PartialFlashing.flashAsync(window.dapwrapper, output, updateProgress);
                 })
 
         }


### PR DESCRIPTION
Draft for now

I've removed the full flash code from partial flashing: flashing each page appears to be as fast, simplifies the code a bit, and avoids daplink getting out of sync

Still digging around to figure out why partial and full cause issues for each other