### PR TITLE
Enable console.log for partial flashing

### DIFF
--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -38,8 +38,7 @@
 let PartialFlashingUtils = {
     pageSize: 1024,
     numPages: 256,
-    log: function() {},
-    // log: console.log,
+    log: console.log,
 
     // The Control/Status Word register is used to configure and control transfers through the APB interface.
     // This is drawn from https://github.com/mmoskal/dapjs/blob/a32f11f54e9e76a9c61896ddd425c1cb1a29c143/src/dap/constants.ts#L28

--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -695,6 +695,7 @@ let PartialFlashing = {
         } catch (err) {
             // Fall back to full flash if attempting to reset times out.
             if (err === "Timeout") {
+                PartialFlashingUtils.log("Partial flashing failed. Attempting Full Flash");
                 return this.fullFlashAsync(dapwrapper, image);
             }
             return Promise.reject(err);


### PR DESCRIPTION
Partial flashing will log events to the console to help users debug and send error reports