### PR TITLE
Update crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,13 @@
+"project_identifier" : "microbitorg"
+"api_key_env" : CROWDIN_API_KEY
+"base_path" : "./lang"
+"preserve_hierarchy": true
+
+files: [
+ {
+  "source" : "en.js",
+  "dest" : "new/apps/python-editor/en.json",
+  "type" : "json",
+  "translation" : "apps/python-editor/%two_letters_code%.js"
+ }
+] 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -8,6 +8,6 @@ files: [
   "source" : "en.js",
   "dest" : "new/apps/python-editor/en.json",
   "type" : "json",
-  "translation" : "apps/python-editor/%two_letters_code%.js"
+  "translation" : "/%two_letters_code%.js"
  }
 ] 

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,7 +6,7 @@
 files: [
  {
   "source" : "en.js",
-  "dest" : "new/apps/python-editor/en.json",
+  "dest" : "/apps/python-editor/en.json",
   "type" : "json",
   "translation" : "/%two_letters_code%.js"
  }


### PR DESCRIPTION
fixes path for exported files so they are saved in the /lang directory