### PR TITLE
Moved webusb timeout message so it only shows when the timeout is valid

### DIFF
--- a/partial-flashing.js
+++ b/partial-flashing.js
@@ -699,7 +699,6 @@ let PartialFlashing = {
 
             let timeout = new Promise((resolve, reject) => {
                 setTimeout(() => {
-                    PartialFlashingUtils.log("Resetting micro:bit timed out");
                     reject('Timeout')
                 }, 1000)
             })
@@ -717,6 +716,7 @@ let PartialFlashing = {
         } catch (err) {
             // Fall back to full flash if attempting to reset times out.
             if (err === "Timeout") {
+                PartialFlashingUtils.log("Resetting micro:bit timed out");
                 PartialFlashingUtils.log("Partial flashing failed. Attempting Full Flash");
                 // Send event
                 var details = {


### PR DESCRIPTION
Previously the time out message was printed to the console with no regard to whether the promise had won/lost the race

Now the timeout failed message is only printed when the timeout promise has won the race