### PR TITLE
Render all buttons for IE10

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -81,6 +81,7 @@ Nicholas and Damien.
             EDITOR_VERSION = "2.0.0-beta.5";
             UPY_VERSION = "1.0.1";
         </script>
+        <html data-useragent="Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)"></html>
         <script id="files-template" type="x-tmpl-mustache">
             <h2 class="modal-title"><i class="fa fa-upload"></i> <strong>{{ load-title }}</strong></h2>
             <div class="load-drag-target" id="load-drag-target">

--- a/python-main.js
+++ b/python-main.js
@@ -52,6 +52,10 @@ var EDITOR_IFRAME_MESSAGING = Object.freeze({
   }
 })
 
+//Allows for different CSS styling in IE10
+var doc = document.documentElement;
+doc.setAttribute('data-useragent', navigator.userAgent);
+
 /*
 Returns an object that defines the behaviour of the Python editor. The editor
 is attached to the div with the referenced id.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -156,6 +156,20 @@ h2 {
   color: #336699;
   background: #FFFFFF;
 }
+html[data-useragent*='MSIE 10.0'] #small-icons .status-icon  {
+  width: 37px;
+  height: 37px;
+  border: 6px solid #FFCC33;
+  border-radius: 50%;
+  margin: .2rem;
+  text-align: center;
+  font-size: 1.4rem;
+  line-height: 2.15rem;
+  padding: 0;
+  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Symbola", sans-serif;
+  color: #336699;
+  background: #FFFFFF; 
+}
 
 #small-icons .holder {
   width: 56px;
@@ -282,6 +296,21 @@ h2 {
   text-align: center;
   font-size: 2.6rem;
   line-height: 4.4rem;
+  padding: .1em;
+  font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Symbola", sans-serif;
+  color: #336699;
+  background: #FFFFFF;
+}
+html[data-useragent*='MSIE 10.0'] .roundsymbol {
+  width: 4rem;
+  height: 4rem;
+  border: 6px solid #FFCC33;
+  border-radius: 50%;
+  margin: .2rem;
+  margin-bottom: 0;
+  text-align: center;
+  font-size: 2.6rem;
+  line-height: 3.7rem;
   padding: .1em;
   font-family: "Segoe UI Emoji", "Segoe UI Symbol", "Symbola", sans-serif;
   color: #336699;


### PR DESCRIPTION
These changes will affect the small buttons and the Beta and Help icons (as these are the two non svg .roundsymbol buttons which were not being rendered properly.