### PR TITLE
Added a test case for the webusb error modal

### DIFF
--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -99,14 +99,14 @@ You will need
 Tests Execution
 ---------------
 
-The test cases listed below always need to be run in a Chrome-based browser:
+The test cases listed below always need to be run in a chrome-based browser:
 
 - Connect and Flash over WebUSB and use REPL.
 - WebUSB error modal links are working.
 
 For a Primary Editor release run all the tests in all browsers. For a Beta
 Editor release, run all tests in Internet Explorer 10, except for the
-test cases listed above that need to be run in a Chrome-based browser.
+test cases listed above that need to be run in a chrome-based browser.
 
 Start each test case in a new instance of the Python Editor.
 
@@ -392,7 +392,7 @@ Test Case: Zoom changes the Text Editor font size
 
 Test Case: Connect and Flash over WebUSB and use REPL
 '''''''''''''''''''''''''''''''''''''''''''''''''''''
-Carry out this test in Chrome or a Chrome-powered browser:
+Carry out this test in Chrome or a chrome-based browser:
 - [ ] Connect to micro:bit and confirm that menu now shows options to "Flash" and "Disconnect".
 - [ ] Confirm you can flash the default program to the micro:bit via WebUSB and that it behaves as expected.
 - [ ] "Open Serial" and confirm you can enter the REPL by click or CTRL-C.
@@ -415,7 +415,7 @@ Carry out this test in non-Chrome-based browsers
 
 Test Case: WebUSB error modal links are working
 '''''''''''''''''''''''''''''''''''''''''''''''
-Carry out this test in Chrome or a Chrome-powered browser:
+Carry out this test in Chrome or a chrome-based browser:
 - Click the 'Connect' button.
 - Click 'Cancel' button in the modal that opens.
 - Click the 'Download Hex' link in the modal that opens.

--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -427,7 +427,6 @@ Carry out this test in Chrome or a chrome-based browser:
 - [ ] Confirm the modal closes.
 
 
-
 Test Case: Autocomplete
 '''''''''''''''''''''''
 - [ ] Start typing in the editor and confirm that autocomplete offers suggestions

--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -417,7 +417,7 @@ Test Case: WebUSB error modal links are working
 '''''''''''''''''''''''''''''''''''''''''''''''
 Carry out this test in Chrome or a chrome-based browser:
 - Click the 'Connect' button.
-- Click 'Cancel' button in the modal that opens.
+- Click 'Cancel' button in the WebUSB device selection window that opens.
 - Click the 'Download Hex' link in the modal that opens.
 - [ ] Confirm a hex file with the name 'microbit_program.hex' is downloaded.
 - Click the 'Troubleshoot' link.

--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -99,10 +99,14 @@ You will need
 Tests Execution
 ---------------
 
+The test cases listed below always need to be run in a Chrome-based browser:
+
+- Connect and Flash over WebUSB and use REPL.
+- WebUSB error modal links are working.
+
 For a Primary Editor release run all the tests in all browsers. For a Beta
 Editor release, run all tests in Internet Explorer 10, except for the
-"Connect and Flash over WebUSB and use REPL" test case, which has to be run
-in a Chrome-based browser.
+test cases listed above that need to be run in a Chrome-based browser.
 
 Start each test case in a new instance of the Python Editor.
 
@@ -399,7 +403,7 @@ Carry out this test in Chrome or a Chrome-powered browser:
 Test Case: WebUSB not supported message is working
 ''''''''''''''''''''''''''''''''''''''''''''''''''
 Carry out this test in non-Chrome-based browsers 
-- Click the 'Connect' button .
+- Click the 'Connect' button.
 - [ ] Confirm the WebUSB not supported message box is displayed.
 - Click the 'Open Serial' button.
 - [ ] Confirm the WebUSB not supported message box is displayed.
@@ -407,6 +411,21 @@ Carry out this test in non-Chrome-based browsers
 - [ ] Confirm the help.html page is opened on the WebUSB section.
 - Click outside the modal.
 - [ ] Confirm the modal closes.
+
+
+Test Case: WebUSB error modal links are working
+'''''''''''''''''''''''''''''''''''''''''''''''
+Carry out this test in Chrome or a Chrome-powered browser:
+- Click the 'Connect' button.
+- Click 'Cancel' button in the modal that opens.
+- Click the 'Download Hex' link in the modal that opens.
+- [ ] Confirm a hex file with the name 'microbit_program.hex' is downloaded.
+- Click the 'Troubleshoot' link.
+- [ ] Confirm that https://support.microbit.org/support/solutions/articles/19000105428-webusb-troubleshooting is opened in a new tab.
+- Close the troubleshooting tab.
+- Click the 'Close' link.
+- [ ] Confirm the modal closes.
+
 
 
 Test Case: Autocomplete


### PR DESCRIPTION
Added test case to make sure the three links in the WebUSB error modal work. The modal is shown when the connect button is pressed but then no device is selected and the user instead presses cancel. I then added to the instructions so that the tester is reminded that they need to carry out that test in chrome or a chrome-based browser