### PR TITLE
A11y: Document encoding should be in the first 1024 bytes.

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en" data-useragent="Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)">
-    <!--
+    <head>
+        <meta charset="utf-8">
+        <!--
                                                                              .:://++++++//:-.
                                                                            .++/::++++++++++++/`
                                                                            :++   /+++++++++++/:
@@ -57,9 +59,7 @@ Express yourself with MicroPython.
 Happy hacking,
 
 Nicholas and Damien.
-    -->
-    <head>
-        <meta charset="utf-8">
+        -->
         <title>Python editor</title>
         <meta name="viewport" content="width=device-width,initial-scale=1">
         <link rel="stylesheet" type="text/css" href="static/css/style.css" />


### PR DESCRIPTION
We have this warning coming up in the IE console, since the charset is not in the first 1024 bytes of  the document: https://www.w3.org/International/questions/qa-html-encoding-declarations