### PR TITLE
WebUSB: Always reset the serial terminal when closed

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1484,16 +1484,8 @@ function web_editor(config) {
 
         // Hide serial and disconnect if open
         if ($("#repl").css('display') != 'none') {
-            $("#repl").hide();
-            $("#request-repl").hide();
-            $("#request-serial").hide();
-            $("#editor-container").show();
+            closeSerial();
         }
-        $("#command-serial").attr("title", config["translate"]["static-strings"]["buttons"]["command-serial"]["title"]);
-        $("#command-serial > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-serial"]["label"]);
-
-        $("#repl").empty();
-        REPL = null;
 
         // Change button to connect
         $("#command-disconnect").hide();
@@ -1509,15 +1501,13 @@ function web_editor(config) {
         if (usePartialFlashing) {
             if (window.dapwrapper) {
                 console.log("Disconnecting: Using Quick Flash");
-                p = p.then(function() { window.dapwrapper.daplink.stopSerialRead() } )
-                    .then(function() { window.dapwrapper.disconnectAsync() } );
+                p = p.then(function() { window.dapwrapper.disconnectAsync() } );
             }
         }
         else {
             if (window.daplink) {
                 console.log("Disconnecting: Using Full Flash");
-                p = p.then(function() { window.daplink.stopSerialRead() } )
-                    .then(function() { window.daplink.disconnect() } );
+                p = p.then(function() { window.daplink.disconnect() } );
             }
         }
 
@@ -1538,21 +1528,7 @@ function web_editor(config) {
 
         // Hide serial and disconnect if open
         if ($("#repl").css('display') != 'none') {
-            $("#repl").hide();
-            $("#request-repl").hide();
-            $("#request-serial").hide();
-            $("#editor-container").show();
-            $("#command-serial").attr("title", config["translate"]["static-strings"]["buttons"]["command-serial"]["title"]);
-            $("#command-serial > .roundlabel").text(config["translate"]["static-strings"]["buttons"]["command-serial"]["label"]);
-
-            if (usePartialFlashing) {
-                if (window.dapwrapper) {
-                    window.dapwrapper.daplink.stopSerialRead();
-                }
-            }
-            else {
-                window.daplink.stopSerialRead();
-            }
+            closeSerial();
         }
 
         // Get the hex to flash in bytes format, exit if there is an error
@@ -1580,9 +1556,6 @@ function web_editor(config) {
 
         var p = Promise.resolve();
         if (usePartialFlashing) {
-            REPL = null;
-            $("#repl").empty();
-
             p = window.dapwrapper.disconnectAsync()
                 .then(function() {
                     return PartialFlashing.connectDapAsync();
@@ -1640,25 +1613,29 @@ function web_editor(config) {
         });
     }
 
+    function closeSerial(keepSession) {
+        console.log("Closing Serial Terminal");
+        $("#repl").empty();
+        $("#repl").hide();
+        $("#request-repl").hide();
+        $("#request-serial").hide();
+        $("#editor-container").show();
+
+        var serialButton = config["translate"]["static-strings"]["buttons"]["command-serial"];
+        $("#command-serial").attr("title", serialButton["title"]);
+        $("#command-serial > .roundlabel").text(serialButton["label"]);
+
+        var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
+        daplink.stopSerialRead();
+        REPL = null;
+    }
+
     function doSerial() {
         console.log("Setting Up Serial Terminal");
         // Hide terminal
         var serialButton = config["translate"]["static-strings"]["buttons"]["command-serial"];
         if ($("#repl").css('display') != 'none') {
-            $("#repl").hide();
-            $("#request-repl").hide();
-            $("#request-serial").hide();
-            $("#editor-container").show();
-            $("#command-serial").attr("title", serialButton["label"]);
-            $("#command-serial > .roundlabel").text(serialButton["label"]);
-            if (usePartialFlashing) {
-                if (window.dapwrapper) {
-                    window.dapwrapper.daplink.stopSerialRead();
-                }
-            }
-            else {
-                window.daplink.stopSerialRead();
-            }
+            closeSerial();
             return;
         }
 

--- a/python-main.js
+++ b/python-main.js
@@ -1627,18 +1627,21 @@ function web_editor(config) {
 
         var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
         daplink.stopSerialRead();
+        daplink.removeAllListeners(DAPjs.DAPLink.EVENT_SERIAL_DATA);
+        REPL.uninstallKeyboard();
+        REPL.io.pop();
         REPL = null;
     }
 
     function doSerial() {
-        console.log("Setting Up Serial Terminal");
-        // Hide terminal
+        // Hide terminal if it is currently shown
         var serialButton = config["translate"]["static-strings"]["buttons"]["command-serial"];
         if ($("#repl").css('display') != 'none') {
             closeSerial();
             return;
         }
 
+        console.log("Setting Up Serial Terminal");
         // Check if we need to connect
         if ($("#command-connect").is(":visible")){
             doConnect(true);

--- a/python-main.js
+++ b/python-main.js
@@ -1462,7 +1462,7 @@ function web_editor(config) {
         $('#flashing-overlay').keydown(function(e) {
             if (e.which == 27) {
                 flashErrorClose();
-           }
+            }
         });
 
         // Send event
@@ -1498,17 +1498,13 @@ function web_editor(config) {
 
         var p = Promise.resolve();
 
-        if (usePartialFlashing) {
-            if (window.dapwrapper) {
-                console.log("Disconnecting: Using Quick Flash");
-                p = p.then(function() { window.dapwrapper.disconnectAsync() } );
-            }
+        if (usePartialFlashing && window.dapwrapper) {
+            console.log('Disconnecting: Using Quick Flash');
+            p = p.then(function() { return window.dapwrapper.disconnectAsync() });
         }
-        else {
-            if (window.daplink) {
-                console.log("Disconnecting: Using Full Flash");
-                p = p.then(function() { window.daplink.disconnect() } );
-            }
+        else if (window.daplink) {
+            console.log('Disconnecting: Using Full Flash');
+            p = p.then(function() { return window.daplink.disconnect() });
         }
 
         p.finally(function() {
@@ -1615,15 +1611,15 @@ function web_editor(config) {
 
     function closeSerial(keepSession) {
         console.log("Closing Serial Terminal");
-        $("#repl").empty();
-        $("#repl").hide();
-        $("#request-repl").hide();
-        $("#request-serial").hide();
-        $("#editor-container").show();
+        $('#repl').empty();
+        $('#repl').hide();
+        $('#request-repl').hide();
+        $('#request-serial').hide();
+        $('#editor-container').show();
 
-        var serialButton = config["translate"]["static-strings"]["buttons"]["command-serial"];
-        $("#command-serial").attr("title", serialButton["title"]);
-        $("#command-serial > .roundlabel").text(serialButton["label"]);
+        var serialButton = config['translate']['static-strings']['buttons']['command-serial'];
+        $('#command-serial').attr('title', serialButton['title']);
+        $('#command-serial > .roundlabel').text(serialButton['label']);
 
         var daplink = usePartialFlashing ? window.dapwrapper.daplink : window.daplink;
         daplink.stopSerialRead();
@@ -1737,8 +1733,8 @@ function web_editor(config) {
         $(overlayContainer).keydown(function(e) {
             if (e.which == 27) {
                 modalMsgClose();
-           }
-       });
+            }
+        });
     }
 
     function formatMenuContainer(parentButtonId, containerId) {


### PR DESCRIPTION
It does this by refactoring the "serial close" code from multiple places into a single function.

By leaving the content of the terminal when closing the serial it might look like the REPL is still running, which it isn't after a serial reconnection.

In this GIF you can see me opening the REPL, execute a command, and then trying to go back and press the UP key in the keyboard to try to repeat the last command.
Every time the UP key is pressed we can see an error in the console (different issue), and it isn't until Ctrl+C is pressed that the REPL is running again.

![ezgif-2-48539878020a](https://user-images.githubusercontent.com/29712657/71084586-88f3b600-218d-11ea-823e-b55f30b0ff52.gif)


I think this also possibly fixes the issue that was reported by some users where typing in the terminal would print on the screen the same character multiple times.