### PR TITLE
a11y: make link into button

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -86,7 +86,7 @@ Nicholas and Damien.
             <h2 class="modal-title"><i class="fa fa-upload"></i> <strong>{{ load-title }}</strong></h2>
             <div class="load-drag-target" id="load-drag-target">
                 <input type="file" style="display: none" name="load-form-file-upload" id="file-upload-input">
-                <p>{{ instructions }}<br><a href="#" id="file-upload-link" class="load-drag-target load-toggle action">{{ toggle-file }}</a></p>
+                <p>{{ instructions }}<br><button aria-labelledby="file-upload-link" type="button" id="file-upload-link" class="load-drag-target load-toggle button-link action">{{ toggle-file }}</button></p>
             </div>
             <h2 class="modal-title"><i class="fa fa-download"></i> <strong>{{ save-but }}</strong></h2>
             <div class="save-buttons-container">

--- a/python-main.js
+++ b/python-main.js
@@ -1709,7 +1709,7 @@ function web_editor(config) {
 
                     addCloseClickListener = true;
                 } else {
-                    modalLinks.push('<button type="button" aria-label="' + key + '"class="button-link" onclick="window.open(\' ' + links[key] + '\', \'_blank\')">' + key + '</button>');
+                    modalLinks.push('<button type="button" aria-label="' + key + '" class="button-link" onclick="window.open(\' ' + links[key] + '\', \'_blank\')">' + key + '</button>');
                 }
             });
         }

--- a/python-main.js
+++ b/python-main.js
@@ -1705,10 +1705,11 @@ function web_editor(config) {
         if (links) {
             Object.keys(links).forEach(function(key) {
                 if (links[key] === "close") {
-                    modalLinks.push('<a href="#" id="modal-msg-close-link">' + key + '</a>');
+                    modalLinks.push('<button type="button" area-labelledby="modal-msg-close-link" id="modal-msg-close-link">' + key + '</button>');
+
                     addCloseClickListener = true;
                 } else {
-                    modalLinks.push('<a href="' + links[key] + '" target="_blank">' + key + '</a>');
+                    modalLinks.push('<button type="button" aria-label="' + key + '"class="button-link" onclick="window.open(\' ' + links[key] + '\', \'_blank\')">' + key + '</button>');
                 }
             });
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -957,6 +957,20 @@ input:checked + .menu-switch-slider:before {
     float: right;
 }
 
+.button-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 1rem;
+  color: #326699;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+#file-upload-link {
+  font-weight: bold ;
+}
+
 .disabled {
     pointer-events: none;
     cursor: not-allowed;


### PR DESCRIPTION
fixes https://github.com/microbit-foundation/platform-software-issue-tracker/issues/596
Buttons are accessible by default as opposed to links
**Before**
<img width="806" alt="Screenshot 2019-12-19 at 10 49 23" src="https://user-images.githubusercontent.com/31242877/71175159-be1c0900-225e-11ea-9a39-87a93c67387b.png">
**After**
<img width="854" alt="Screenshot 2019-12-19 at 10 50 08" src="https://user-images.githubusercontent.com/31242877/71175135-afcded00-225e-11ea-9c00-30d98d2e0144.png">
