### PR TITLE
WebUSB: Focus the serial termianl when REPL button is pressed.

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1813,10 +1813,19 @@ function web_editor(config) {
             });
             $("#command-disconnect").click(function () {
                 doDisconnect();
-            }); 
+            });
             $("#command-serial").click(function () {
                 doSerial();
-            });  
+            });
+            $("#request-repl").click(function () {
+                var daplink = usePartialFlashing && window.dapwrapper ? window.dapwrapper.daplink : window.daplink;
+                daplink.serialWrite('\x03');
+                REPL.focus();
+            });
+            $("#request-serial").click(function () {
+                var daplink = usePartialFlashing && window.dapwrapper ? window.dapwrapper.daplink : window.daplink;
+                daplink.serialWrite('\x04');
+            });
         } else {
             var WebUSBUnavailable = function() {
                 var links = {};
@@ -1833,14 +1842,6 @@ function web_editor(config) {
                 e.stopPropagation();
             });
         }
-        $("#request-repl").click(function () {
-            var daplink = usePartialFlashing && window.dapwrapper ? window.dapwrapper.daplink : window.daplink;
-            daplink.serialWrite("\x03");
-        });
-        $("#request-serial").click(function () {
-            var daplink = usePartialFlashing && window.dapwrapper ? window.dapwrapper.daplink : window.daplink;
-            daplink.serialWrite("\x04");
-        });
         $("#command-options").click(function (e) {
             // Hide any other open menus and show/hide options menu
             $('#helpsupport_container').addClass('hidden');


### PR DESCRIPTION
This saves the user having to then click on the terminal panel.

It also moves the REPL and reset click listeners to only be initialised when WebUSB is available.
Doesn't make much of a difference, but at least it keep the WebUSB init code closer together.