### PR TITLE
Delete titles on error modal links

### DIFF
--- a/python-main.js
+++ b/python-main.js
@@ -1418,10 +1418,10 @@ function web_editor(config) {
         // If err is not device disconnected or if there is previous errors, append the download/troubleshoot buttons
         var showOverlayButtons = "";
         if(err.name !== 'device-disconnected' || $("#flashing-overlay-error").html() !== "") {
-            showOverlayButtons = '<a href="#" id="flashing-overlay-download" class="action" onclick="actionClickListener(event)">' +
+            showOverlayButtons = '<a title="" href="#" id="flashing-overlay-download" class="action" onclick="actionClickListener(event)">' +
                                     config["translate"]["webusb"]["download"] + 
                                  '</a> | ' +
-                                 '<a target="_blank" href="https://support.microbit.org/solution/articles/19000105428-webusb-troubleshooting/en" id="flashing-overlay-troubleshoot" class="action" onclick="actionClickListener(event)">' +
+                                 '<a title="" target="_blank" href="https://support.microbit.org/solution/articles/19000105428-webusb-troubleshooting/en" id="flashing-overlay-troubleshoot" class="action" onclick="actionClickListener(event)">' +
                                     config["translate"]["webusb"]["troubleshoot"] + 
                                 '</a> | ';
         }
@@ -1436,7 +1436,7 @@ function web_editor(config) {
                     '<div class="flashing-overlay-buttons">' + 
                         '<hr />' +
                         showOverlayButtons + 
-                        '<a href="#" onclick="flashErrorClose()">' + config["translate"]["webusb"]["close"] + '</a>' + 
+                        '<a title="" href="#" onclick="flashErrorClose()">' + config["translate"]["webusb"]["close"] + '</a>' + 
                     '</div>';
 
         // Show error message, or append to existing errors


### PR DESCRIPTION
Although there was no explicit 'title' attribute before, the 'connect to the micro:bit' title from the 'connect' div (parent) was sometimes (temperamentally) showing up. In order to erase the chance of this happening, I have set the titles to nothing. 