### PR TITLE
Add postMessage for mobile apps

### DIFF
--- a/js/python-main.js
+++ b/js/python-main.js
@@ -363,10 +363,11 @@ function web_editor(config) {
 
     // Indicate if editor can listen and respond to messages
     var inIframe = window !== window.parent;
-    var controllerMode = (inIframe && urlparse("controller") === "1") || urlparse("controller") === "2";
-    var enableAppMode = 0;
+    var controllerMode = (inIframe && urlparse("controller") === "1");
+    var appMode = urlparse("mobileApp") === "1";
 
     var usePartialFlashing = true;
+    var usePostMessageFlashing = false;
 
     // Sets the name associated with the code displayed in the UI.
     function setName(x) {
@@ -600,7 +601,7 @@ function web_editor(config) {
                 
                 // Parent is requesting app mode. Downloads will use postMessage
                 case EDITOR_IFRAME_MESSAGING.actions.enableappmode:
-                  enableAppMode = event.data.enabled;
+                  usePostMessageFlashing = event.data.enabled;
                   break;
 
                 default:
@@ -757,8 +758,7 @@ function web_editor(config) {
 
     // Downloads a file from the filesystem, main.py is renamed to the script name
     function downloadFileFromFilesystem(filename) {
-        //Use webkit host postMessage
-        if (enableAppMode) {
+        if (usePostMessageFlashing) {
             var output = FS.readBytes(filename);
             if (filename === 'main.py') {
                 filename = getSafeName() + '.py';
@@ -927,8 +927,7 @@ function web_editor(config) {
             alert(config.translate.alerts.error + '\n' + e.message);
             return;
         }
-        //Use webkit host postMessage
-        if (enableAppMode) {
+        if (usePostMessageFlashing) {
             var filename = getSafeName() + '.hex';
             webkitHostMsgSave(filename,output)
             return;
@@ -1415,7 +1414,7 @@ function web_editor(config) {
     }
 
     function doFlash() {
-        if (enableAppMode) {
+        if (usePostMessageFlashing) {
             webkitHostMsgFlash();
             return;
         }
@@ -1808,7 +1807,7 @@ function web_editor(config) {
             }
         });
           
-        if ( enableAppMode )
+        if ( appMode )
         {
           $("#command-connect").hide();
           $("#command-serial").hide();
@@ -1853,7 +1852,7 @@ function web_editor(config) {
     });
 
     // If iframe messaging allowed, initialize it
-    if (controllerMode) {
+    if (controllerMode || appMode) {
       initializeIframeMessaging();
     }
 }

--- a/js/python-main.js
+++ b/js/python-main.js
@@ -45,7 +45,7 @@ function debounce(callback, wait) {
 // Constants used for iframe messaging
 var EDITOR_IFRAME_MESSAGING = Object.freeze({
   // Embed editor host type
-  host: "pyeditor",
+  type: "pyeditor",
   // Embed editor messaging actions
   actions: {
     workspacesync: "workspacesync",
@@ -554,7 +554,7 @@ function web_editor(config) {
 
     function initializeIframeMessaging() {
       window.addEventListener("load", function () {
-        window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.host, action: EDITOR_IFRAME_MESSAGING.actions.workspacesync }, "*");
+        window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.type, action: EDITOR_IFRAME_MESSAGING.actions.workspacesync }, "*");
       });
 
       window.addEventListener(
@@ -563,7 +563,7 @@ function web_editor(config) {
           if (event.data) {
             var type = event.data.type;
 
-            if (type === EDITOR_IFRAME_MESSAGING.host) {
+            if (type === EDITOR_IFRAME_MESSAGING.type) {
               var action = event.data.action;
               
               switch (action) {
@@ -586,7 +586,7 @@ function web_editor(config) {
                   }
                   EDITOR.setCode(event.data.projects[0]);
                   // Notify parent about editor successfully configured
-                  window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.host, action: EDITOR_IFRAME_MESSAGING.actions.workspaceloaded }, "*");
+                  window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.type, action: EDITOR_IFRAME_MESSAGING.actions.workspaceloaded }, "*");
                   break;
                
                 // Parent is sending HEX file
@@ -614,7 +614,7 @@ function web_editor(config) {
       );
 
       var debounceCodeChange = debounce(function (code) {
-        window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.host, action: EDITOR_IFRAME_MESSAGING.actions.workspacesave, project: code }, "*");
+        window.parent.postMessage({ type: EDITOR_IFRAME_MESSAGING.type, action: EDITOR_IFRAME_MESSAGING.actions.workspacesave, project: code }, "*");
       }, 1000);
 
       EDITOR.setCode(" ");
@@ -624,6 +624,8 @@ function web_editor(config) {
     }
 
     function webkitHostMsgFile(name,data,action) {
+        // 'host' refers to the app embedding the editor. We use 'host' here to 
+        // match the MakeCode messageHandler name
         window.webkit.messageHandlers.host.postMessage({'name': name,action:data});
     }
                       

--- a/js/python-main.js
+++ b/js/python-main.js
@@ -54,7 +54,7 @@ var EDITOR_IFRAME_MESSAGING = Object.freeze({
     importproject: "importproject",
     loadhex: "loadhex",
     loadfile: "loadfile",
-    enableappmode: "enableappmode"
+    downloadmode: "downloadmode"
   }
 })
 
@@ -599,8 +599,8 @@ function web_editor(config) {
                   loadFileToFilesystem(event.data.filename, event.data.filestring);
                   break;
                 
-                // Parent is requesting app mode. Downloads will use postMessage
-                case EDITOR_IFRAME_MESSAGING.actions.enableappmode:
+                // Parent is requesting postMessage downloads
+                case EDITOR_IFRAME_MESSAGING.actions.downloadmode:
                   usePostMessageFlashing = event.data.enabled;
                   break;
 

--- a/js/python-main.js
+++ b/js/python-main.js
@@ -597,7 +597,8 @@ function web_editor(config) {
                 case EDITOR_IFRAME_MESSAGING.actions.loadfile:
                   loadFileToFilesystem(event.data.filename, event.data.filestring);
                   break;
-
+                
+                // Parent is requesting app mode. Downloads will use postMessage
                 case EDITOR_IFRAME_MESSAGING.actions.enableappmode:
                   enableAppMode = event.data.enabled;
                   break;
@@ -619,14 +620,6 @@ function web_editor(config) {
       EDITOR.on_change(function () {
         debounceCodeChange(EDITOR.getCode());
       });
-    }
-    
-    // functions for webkit postMessage to the 'host' message handler
-    function webkitHostMsgExists() {
-        return window.webkit
-            && window.webkit.messageHandlers
-            && window.webkit.messageHandlers.host
-            && window.webkit.messageHandlers.host.postMessage;
     }
 
     function webkitHostMsgFile(name,data,action) {


### PR DESCRIPTION
Allows a browser / web view to use postMessage to upload / download files from the Python Editor
Intended for use with the micro:bit mobile apps