### PR TITLE
Updating the Manual tests procedure with clarifications

### DIFF
--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -251,18 +251,18 @@ Code block 8::
     display.show(Image.PACMAN)
 
 
-Test Case: module.py file can be loaded by file picker and used in main.py
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-- Load by Load/Save > Or browse for a file, the file ``emoji.py``
-- [ ] Confirm the modal dialogue displays 'The "emoji" module has been added to the filesystem.'
+Test Case: module.py file can be loaded by modal file picker and used in main.py
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+- Load by "Load/Save > Or browse for a file" the file ``emoji.py``
+- [ ] Confirm the modal dialogue displays 'The "emoji" module has been added
+  to the filesystem.'
+- Click "Show Files (2)"
 - [ ] Confirm the file shows up in the files list with the same title.
+- Return to the editor and replace the current script with "Code block 9".
+- [ ] Program by any method this file to the micro:bit and confirm that it
+  behaves as expected, showing emojis for the appropriate gestures and buttons.
 
-
-Test Case: module.py file can be loaded by file picker and used in main.py
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
-- Load by Load/Save > Add file the file ``emoji.py``
-- [ ] Confirm the file shows up in the files list with the same title.
-- Return to the editor and replace the current script with the following::
+Code block 9::
 
     from microbit import *
     from emoji import *
@@ -280,65 +280,26 @@ Test Case: module.py file can be loaded by file picker and used in main.py
             sleep(2000)
         sleep(100)
 
-- [ ] Program by any method this file to the micro:bit and confirm that it
-  behaves as expected, showing emojis for the appropriate gestures and buttons.
+
+Test Case: module.py file can be loaded by filesystem file picker
+'''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+- Load by "Load/Save > Show Files > Add file" the file ``emoji.py``
+- [ ] Confirm the file shows up in the files list with the same title.
 
 
-Test Case: module.py file can be 'magically' loaded into the editor by drag&drop and used in main.py
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Test Case: module.py file can be 'magically' loaded into the editor by drag&drop
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 - Load by drag&drop into the editor the file ``emoji.py``
 - [ ] Confirm the modal dialogue displays 'The "emoji" module has been added
   to the filesystem.'
 - [ ] Confirm the file shows up in the files list with the same title.
-- Return to the editor and replace the current script with the following::
 
 
-    from microbit import *
-    from emoji import *
-
-    while True:
-        display.show(😃)
-        if accelerometer.was_gesture('shake'):
-            display.show(😡)
-            sleep(2000)
-        if button_a.was_pressed():
-            display.show(💖)
-            sleep(2000)
-        elif button_b.was_pressed():
-            display.show(🏠)
-            sleep(2000)
-        sleep(100)
-
-- [ ] Program by any method this file to the micro:bit and confirm that it
-  behaves as expected, showing emojis for the appropriate gestures and buttons.
-
-
-Test Case: module.py file can be loaded by Load/Save modal drag&drop and used in main.py
-''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Test Case: module.py file can be loaded by Load/Save modal drag&drop
+''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 - Load by Load/Save drop area drag&drop the file ``emoji.py``
 - [ ] Confirm the modal dialogue displays 'The "emoji" module has been added
   to the filesystem.'
-- Return to the editor and replace the current script with the following::
-
-
-    from microbit import *
-    from emoji import *
-
-    while True:
-        display.show(😃)
-        if accelerometer.was_gesture('shake'):
-            display.show(😡)
-            sleep(2000)
-        if button_a.was_pressed():
-            display.show(💖)
-            sleep(2000)
-        elif button_b.was_pressed():
-            display.show(🏠)
-            sleep(2000)
-        sleep(100)
-
-- [ ] Program by any method this file to the micro:bit and confirm that it
-  behaves as expected, showing emojis for the appropriate gestures and buttons.
 
 
 Test Case: Hex file containing module can be loaded in the editor
@@ -366,10 +327,10 @@ Test Case: Snippets inject code into the Text Editor
 ''''''''''''''''''''''''''''''''''''''''''''''''''''
 - Click the "Snippets" button.
 - Click on the "if" trigger.
-- [ ] Confirm the contents defined in "Code block 9" were injected to the end
+- [ ] Confirm the contents defined in "Code block 10" were injected to the end
   of the Text Editor (where the cursor should be by default).
 
-Code block 9::
+Code block 10::
 
     if condition:
         # TODO: write code...

--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -405,15 +405,14 @@ Test Case: Language options work
 - Confirm that selecting each language option changes it to the corresponding language
 
 - [ ] English
+- [ ] Chinese (Hong Kong)
 - [ ] Chinese (simplified)
-- [ ] Chinese (traditional Hong Kong)
-- [ ] Traditional Taiwanese
+- [ ] Chinese (Taiwan)
 - [ ] Croatian
 - [ ] Polish
 - [ ] Spanish
 - [ ] French
 - [ ] Korean
-- [ ] Norwegian Bokmal
 - [ ] Norwegian Nynorsk
 - [ ] Portugese
 - [ ] Serbian

--- a/tests/manual/test-procedure.rst
+++ b/tests/manual/test-procedure.rst
@@ -88,7 +88,9 @@ You will need
 
 - The test files from `./test-files/`
 
-- A micro:bit
+- A micro:bit V1
+
+- A micro:bit V2
 
 - One from the following:
 
@@ -253,14 +255,18 @@ Code block 8::
 
 Test Case: module.py file can be loaded by modal file picker and used in main.py
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Run this test case with a micro:bit **V1**.
+
 - Load by "Load/Save > Or browse for a file" the file ``emoji.py``
 - [ ] Confirm the modal dialogue displays 'The "emoji" module has been added
   to the filesystem.'
 - Click "Show Files (2)"
 - [ ] Confirm the file shows up in the files list with the same title.
 - Return to the editor and replace the current script with "Code block 9".
-- [ ] Program by any method this file to the micro:bit and confirm that it
-  behaves as expected, showing emojis for the appropriate gestures and buttons.
+- [ ] Click the "Download" button, copy the hex file via OS drag&drop it into
+  the MICROBIT, confirm it flashes successfully.
+- [ ] Confirm that the programme behaves as expected, showing emojis for the
+  appropriate gestures and buttons.
 
 Code block 9::
 
@@ -283,8 +289,15 @@ Code block 9::
 
 Test Case: module.py file can be loaded by filesystem file picker
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
+Run this test case with a micro:bit **V2**.
+
 - Load by "Load/Save > Show Files > Add file" the file ``emoji.py``
 - [ ] Confirm the file shows up in the files list with the same title.
+- Return to the editor and replace the current script with "Code block 9".
+- [ ] Click the "Download" button, copy the hex file via OS drag&drop it into
+  the MICROBIT, confirm it flashes successfully.
+- [ ] Confirm that the programme behaves as expected, showing emojis for the
+  appropriate gestures and buttons.
 
 
 Test Case: module.py file can be 'magically' loaded into the editor by drag&drop
@@ -381,7 +394,8 @@ Test Case: Language options work
 
 Test Case: Connect and Flash over WebUSB and use REPL
 '''''''''''''''''''''''''''''''''''''''''''''''''''''
-Carry out this test in Chrome or a chrome-based browser:
+Carry out this test in Chrome or a chrome-based browser.
+Run this test case twice, once with a micro:bit V1 and once with a V2.
 
 - [ ] Connect to micro:bit and confirm that menu now shows options to
   "Flash" and "Disconnect".
@@ -395,7 +409,8 @@ Carry out this test in Chrome or a chrome-based browser:
 Test Case: Full Flash over WebUSB
 '''''''''''''''''''''''''''''''''
 This feature will only be available in the beta versions.
-Carry out this test in Chrome or a chrome-based browser:
+Carry out this test in Chrome or a chrome-based browser.
+Run this test case twice, once with a micro:bit V1 and once with a V2.
 
 - Click the 'Beta Options' button.
 - Click the 'Quick Flash' toggle to disable it.


### PR DESCRIPTION
- Updates the translations list
- Clarifies the difference between the two test cases named `module.py file can be loaded by file picker and used in main.py`
- Removes steps remove the (repeating) steps to flash the hex file and check that it works in the multiple test cases that load `module.py` using different methods. If the first time it was added to the filesystem works, then all
the other tests cases will work too.
- Updates the WebUSB test cases to indicate they should be run with a micro:bit V1 and a V2.

@microbit-mark would you be able to review this for me? Thanks!