### PR TITLE
Standardise language names

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -344,9 +344,9 @@ Nicholas and Damien.
                             <span id="lang-select">Select Language:</span>
                             <ul class="tree">
                                 <li><span title="English"><a  href="#" class="action lang-choice" id="en" tabindex="121">English</a></span></li>
-                                <li><span title="Chinese (Hong Kong)"><a lang="zh-HK" href="#" class="action lang-choice" id="zh-HK" tabindex="122">中文 (繁體，香港)</a></span></li>
-                                <li><span title="Chinese (simplified)"><a lang="zh-CN" href="#" class="action lang-choice" id="zh-CN" tabindex="123">简体中文</a></span></li>
-                                <li><span title="Chinese (Taiwan)"><a lang="zh-TW" href="#" class="action lang-choice" id="zh-TW" tabindex="124">中文（繁體，臺灣)</a></span></li>
+                                <li><span title="Chinese (Simplified)"><a lang="zh-CN" href="#" class="action lang-choice" id="zh-CN" tabindex="122">简体中文</a></span></li>
+                                <li><span title="Chinese (Traditional) HK"><a lang="zh-HK" href="#" class="action lang-choice" id="zh-HK" tabindex="123">繁體中文（香港）</a></span></li>
+                                <li><span title="Chinese (Traditional) TW"><a lang="zh-TW" href="#" class="action lang-choice" id="zh-TW" tabindex="124">繁體中文（台灣）</a></span></li>
                                 <li><span title="Croatian"><a lang="hr" href="#" class="action lang-choice" id="hr" tabindex="125">Hrvatski</a></span></li>
                                 <li><span title="Polish"><a lang="pl" href="#" class="action lang-choice" id="pl" tabindex="126">Polski</a></span></li>
                                 <li><span title="Spanish"><a lang="es" href="#" class="action lang-choice" id="es" tabindex="127">Español</a></span></li>

--- a/js/python-main.js
+++ b/js/python-main.js
@@ -336,12 +336,6 @@ function translations(baseLanguage) {
                 $('#' + object).attr('title', helpStrings[object]['title']);
             }
         }
-        var languages = _extendedLang['languages'];
-        for (var object in languages) {
-            if (languages.hasOwnProperty(object)) {
-                $('#' + object).attr('title',languages[object]['title']);
-            }
-        }
         // WebUSB flashing modal
         $('#flashing-extra-msg').text(_extendedLang['webusb']['flashing-long-msg']);
         $('#flashing-title').text(_extendedLang['webusb']['flashing-title']);

--- a/lang/en.js
+++ b/lang/en.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     'mpy-warning' : 'This version of the Python Editor doesn\'t currently support adding .mpy files.',
     'extension-warning' : 'The Python Editor can only load files with the .hex or .py extensions.'
   },
-  'languages': {
-    'en': {
-      'title': 'English'
-    },
-    'zh-CN': {
-      'title': 'Chinese (simplified)'
-    },
-    'zh-HK': {
-      'title': 'Chinese (traditional, Hong Kong)'
-    },
-    'zh-TW': {
-      'title': 'Chinese (traditional, Taiwan)'
-    },
-    'hr': {
-      'title': 'Croatian'
-    },
-    'pl': {
-      'title': 'Polish'
-    },
-    'es': {
-      'title': 'Spanish'
-    },
-    'fr': {
-      'title': 'French'
-    },
-    'ko': {
-      'title': 'Korean'
-    },
-    'nn': {
-      'title': 'Norwegian Nynorsk'
-    },
-    'pt': {
-      'title': 'Portuguese'
-    },
-    'sr': {
-      'title': 'Serbian'
-    }
-  },
   'static-strings': {
     'buttons': {
       'command-download': {

--- a/lang/es.js
+++ b/lang/es.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Esta versión del Editor de Python no permite actualmente añadir archivos .mpy.",
     "extension-warning": "El Editor de Python sólo puede cargar archivos con las extensiones .hex o .py."
   },
-  "languages": {
-    "en": {
-      "title": "Inglés"
-    },
-    "zh-CN": {
-      "title": "Chino (simplificado)"
-    },
-    "zh-HK": {
-      "title": "Chino (tradicional, Hong Kong)"
-    },
-    "zh-TW": {
-      "title": "Chino (tradicional, Taiwan)"
-    },
-    "hr": {
-      "title": "Croata"
-    },
-    "pl": {
-      "title": "Polaco"
-    },
-    "es": {
-      "title": "Español"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/fr.js
+++ b/lang/fr.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Cette version de l'éditeur Python ne supporte pas actuellement l'ajout de fichiers .mpy.",
     "extension-warning": "L'éditeur Python ne peut charger que des fichiers avec les extensions .hex ou .py."
   },
-  "languages": {
-    "en": {
-      "title": "Français"
-    },
-    "zh-CN": {
-      "title": "Chinois (simplifié)"
-    },
-    "zh-HK": {
-      "title": "Chinois (traditionnel, Hong Kong)"
-    },
-    "zh-TW": {
-      "title": "Chinois (traditionnel, Taiwan)"
-    },
-    "hr": {
-      "title": "Croate"
-    },
-    "pl": {
-      "title": "Polonais"
-    },
-    "es": {
-      "title": "Espagnol"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/hr.js
+++ b/lang/hr.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Ova verzija Pythonova uređivača nažalost još ne podržava dodavanje .mpy datoteka.",
     "extension-warning": "Pythonov uređivač može učitati samo datoteke s ekstenzijama .hex ili .py."
   },
-  "languages": {
-    "en": {
-      "title": "Engleski"
-    },
-    "zh-CN": {
-      "title": "Kineski (pojednostavljeni)"
-    },
-    "zh-HK": {
-      "title": "Kineski (tradicionalni, Hong Kong)"
-    },
-    "zh-TW": {
-      "title": "Kineski (tradicionalni)"
-    },
-    "hr": {
-      "title": "Hrvatski"
-    },
-    "pl": {
-      "title": "Poljski"
-    },
-    "es": {
-      "title": "Španjolski"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/ko.js
+++ b/lang/ko.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "이 버전에서는 .mpy 파일 추가를 지원하지 않습니다.",
     "extension-warning": "파이썬 편집기는 .hex 나 .py 확장 파일들만 불러올 수 있습니다."
   },
-  "languages": {
-    "en": {
-      "title": "한국어"
-    },
-    "zh-CN": {
-      "title": "중국어(간체)"
-    },
-    "zh-HK": {
-      "title": "중국어(홍콩)"
-    },
-    "zh-TW": {
-      "title": "중국어 (번체)"
-    },
-    "hr": {
-      "title": "크로아티아어"
-    },
-    "pl": {
-      "title": "폴란드어"
-    },
-    "es": {
-      "title": "스페인어"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/nn.js
+++ b/lang/nn.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Denne versjonen av Python støttar ikkje høvet til å leggje til .mpy-filer.",
     "extension-warning": "Python kan berre laste filer med .hex eller .py-utvidingar."
   },
-  "languages": {
-    "en": {
-      "title": "Norsk Nynorsk"
-    },
-    "zh-CN": {
-      "title": "Kinesisk (forenkla)"
-    },
-    "zh-HK": {
-      "title": "Kinesisk (tradisjonelt, Hongkong)"
-    },
-    "zh-TW": {
-      "title": "Kinesisk (tradisjonelt, Taiwan)"
-    },
-    "hr": {
-      "title": "Kroatisk"
-    },
-    "pl": {
-      "title": "Polsk"
-    },
-    "es": {
-      "title": "Spansk"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/pl.js
+++ b/lang/pl.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Ta wersja edytora Python obecnie nie obsługuje dodawania plików .mpy.",
     "extension-warning": "Edytor Python może jedynie wczytywać pliki z rozszerzeniem .hex lub .py."
   },
-  "languages": {
-    "en": {
-      "title": "Angielski"
-    },
-    "zh-CN": {
-      "title": "Chiński (uproszczony)"
-    },
-    "zh-HK": {
-      "title": "Chiński (tradycyjny, Hong Kong)"
-    },
-    "zh-TW": {
-      "title": "Chiński (tradycyjny, Tajwan)"
-    },
-    "hr": {
-      "title": "Chorwacki"
-    },
-    "pl": {
-      "title": "Polski"
-    },
-    "es": {
-      "title": "Hiszpański"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Esta versão do Editor Python por enquanto não permite adicionar ficheiros .mpy",
     "extension-warning": "O Editor Python só permite carregar ficheiros com extensões .hex ou .py."
   },
-  "languages": {
-    "en": {
-      "title": "Inglês"
-    },
-    "zh-CN": {
-      "title": "Chinês (simplificado)"
-    },
-    "zh-HK": {
-      "title": "Chinês (tradicional, Hong Kong)"
-    },
-    "zh-TW": {
-      "title": "Chinês (tradicional, Taiwan)"
-    },
-    "hr": {
-      "title": "Croata"
-    },
-    "pl": {
-      "title": "Polaco"
-    },
-    "es": {
-      "title": "Castelhano"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/sr.js
+++ b/lang/sr.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "Ова верзија Python едитора не подржава додавање .mpy датотеке.",
     "extension-warning": "Python едитор може да учита само датотеке са екстензијама .hex или .py."
   },
-  "languages": {
-    "en": {
-      "title": "Енглески"
-    },
-    "zh-CN": {
-      "title": "Кинески (поједностављен)"
-    },
-    "zh-HK": {
-      "title": "Кинески (традиционални, Хонг Конг)"
-    },
-    "zh-TW": {
-      "title": "Кинески (традиционални, Тајван)"
-    },
-    "hr": {
-      "title": "Хрватски"
-    },
-    "pl": {
-      "title": "Пољски"
-    },
-    "es": {
-      "title": "Шпански"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/zh-CN.js
+++ b/lang/zh-CN.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "这个版本的 Python Editor 不支持添加 .mpy 文件。",
     "extension-warning": "Python Editor 只能载入 .hex 或 .py 文件。"
   },
-  "languages": {
-    "en": {
-      "title": "英文"
-    },
-    "zh-CN": {
-      "title": "中文（简体）"
-    },
-    "zh-HK": {
-      "title": "繁体中文（中国香港）"
-    },
-    "zh-TW": {
-      "title": "繁体中文（中国台湾）"
-    },
-    "hr": {
-      "title": "克罗地亚语"
-    },
-    "pl": {
-      "title": "波兰语"
-    },
-    "es": {
-      "title": "西班牙语"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/zh-HK.js
+++ b/lang/zh-HK.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "這個版本的 Python Editor 不支持添加 .mpy 檔案。",
     "extension-warning": "Python Editor 只能載入 .hex 或 .py 檔案。"
   },
-  "languages": {
-    "en": {
-      "title": "英文"
-    },
-    "zh-CN": {
-      "title": "中文（簡體）"
-    },
-    "zh-HK": {
-      "title": "中文 (繁體，香港)"
-    },
-    "zh-TW": {
-      "title": "中文（繁體，台灣）"
-    },
-    "hr": {
-      "title": "克羅地亞語"
-    },
-    "pl": {
-      "title": "波蘭語"
-    },
-    "es": {
-      "title": "西班牙語"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {

--- a/lang/zh-TW.js
+++ b/lang/zh-TW.js
@@ -115,44 +115,6 @@ var LANGUAGE = {
     "mpy-warning": "這個版本的 Python 編輯器還不支援添加 .mpy 檔案。",
     "extension-warning": "Python 編輯器只能載入副檔名為 .hex 或 .py 的檔案。"
   },
-  "languages": {
-    "en": {
-      "title": "英文"
-    },
-    "zh-CN": {
-      "title": "中文（簡體）"
-    },
-    "zh-HK": {
-      "title": "中文（繁體，香港）"
-    },
-    "zh-TW": {
-      "title": "中文（繁體，臺灣）"
-    },
-    "hr": {
-      "title": "克羅地亞語"
-    },
-    "pl": {
-      "title": "波蘭語"
-    },
-    "es": {
-      "title": "西班牙语"
-    },
-    "fr": {
-      "title": "French"
-    },
-    "ko": {
-      "title": "Korean"
-    },
-    "nn": {
-      "title": "Norwegian Nynorsk"
-    },
-    "pt": {
-      "title": "Portuguese"
-    },
-    "sr": {
-      "title": "Serbian"
-    }
-  },
   "static-strings": {
     "buttons": {
       "command-download": {


### PR DESCRIPTION
Match other Foundation projects.  Avoid using translations of language names as they're not needed to make a choice of language.